### PR TITLE
write an endpoint for web crawling

### DIFF
--- a/src/components/UIUC-Components/GitHubIngestForm.tsx
+++ b/src/components/UIUC-Components/GitHubIngestForm.tsx
@@ -179,34 +179,6 @@ export default function GitHubIngestForm({
     await new Promise((resolve) => setTimeout(resolve, 8000))
   }
 
-  const formatUrl = (url: string) => {
-    if (!/^https?:\/\//i.test(url)) {
-      url = 'http://' + url
-    }
-    return url
-  }
-  const formatUrlAndMatchRegex = (url: string) => {
-    // fullUrl always starts with http://. Is the starting place of the scrape.
-    // baseUrl is used to construct the match statement.
-
-    // Ensure the url starts with 'http://'
-    if (!/^https?:\/\//i.test(url)) {
-      url = 'http://' + url
-    }
-
-    // Extract the base url including the path
-    const baseUrl = (
-      url.replace(/^https?:\/\//i, '').split('?')[0] as string
-    ).replace(/\/$/, '') // Remove protocol (http/s), split at '?', and remove trailing slash
-
-    const matchRegex = `http?(s)://**${baseUrl}/**`
-
-    return {
-      fullUrl: baseUrl,
-      matchRegex: matchRegex,
-    }
-  }
-
   useEffect(() => {
     if (url && url.length > 0 && validateUrl(url)) {
       setIsUrlUpdated(true)
@@ -349,27 +321,16 @@ export default function GitHubIngestForm({
     scrapeStrategy: string,
   ) => {
     try {
-      if (!url || !courseName) return null
+      const response = await axios.post('/api/scrapeWeb', {
+        url,
+        courseName,
+        maxUrls,
+        scrapeStrategy,
+      })
 
-      const fullUrl = formatUrl(url)
-
-      const postParams = {
-        url: fullUrl,
-        courseName: courseName,
-        maxPagesToCrawl: maxUrls,
-        scrapeStrategy: scrapeStrategy,
-        match: formatUrlAndMatchRegex(fullUrl).matchRegex,
-        maxTokens: 2000000, // basically inf.
-      }
-
-      const response = await axios.post(
-        `https://crawlee-production.up.railway.app/crawl`,
-        {
-          params: postParams,
-        },
-      )
-      // console.log('Response from web scraping endpoint:', response.data)
+      console.log('Response from Next.js API web scraping endpoint:', response.data)
       return response.data
+
     } catch (error: any) {
       console.error('Error during web scraping:', error)
 

--- a/src/components/UIUC-Components/WebScrape.tsx
+++ b/src/components/UIUC-Components/WebScrape.tsx
@@ -67,35 +67,6 @@ const validateUrl = (url: string) => {
   )
 }
 
-const formatUrl = (url: string) => {
-  if (!/^https?:\/\//i.test(url)) {
-    url = 'http://' + url
-  }
-  return url
-}
-
-const formatUrlAndMatchRegex = (url: string) => {
-  // fullUrl always starts with http://. Is the starting place of the scrape.
-  // baseUrl is used to construct the match statement.
-
-  // Ensure the url starts with 'http://'
-  if (!/^https?:\/\//i.test(url)) {
-    url = 'http://' + url
-  }
-
-  // Extract the base url including the path
-  const baseUrl = (
-    url.replace(/^https?:\/\//i, '').split('?')[0] as string
-  ).replace(/\/$/, '') // Remove protocol (http/s), split at '?', and remove trailing slash
-
-  const matchRegex = `http?(s)://**${baseUrl}/**`
-
-  return {
-    fullUrl: baseUrl,
-    matchRegex: matchRegex,
-  }
-}
-
 export const WebScrape = ({
   is_new_course,
   courseName,
@@ -305,29 +276,16 @@ export const WebScrape = ({
       if (!url || !courseName) return null
       console.log('SCRAPING', url)
 
-      const fullUrl = formatUrl(url)
+      const response = await axios.post('/api/scrapeWeb', {
+        url,
+        courseName,
+        maxUrls,
+        scrapeStrategy,
+      })
 
-      const postParams = {
-        url: fullUrl,
-        courseName: courseName,
-        maxPagesToCrawl: maxUrls,
-        scrapeStrategy: scrapeStrategy,
-        match: formatUrlAndMatchRegex(fullUrl).matchRegex,
-        maxTokens: 2000000, // basically inf.
-      }
-      console.log(
-        'About to post to the web scraping endpoint, with params:',
-        postParams,
-      )
-
-      const response = await axios.post(
-        `https://crawlee-production.up.railway.app/crawl`,
-        {
-          params: postParams,
-        },
-      )
-      console.log('Response from web scraping endpoint:', response.data)
+      console.log('Response from Next.js API web scraping endpoint:', response.data)
       return response.data
+
     } catch (error: any) {
       console.error('Error during web scraping:', error)
 

--- a/src/components/UIUC-Components/WebsiteIngestForm.tsx
+++ b/src/components/UIUC-Components/WebsiteIngestForm.tsx
@@ -113,13 +113,6 @@ export default function WebsiteIngestForm({
     maxDepth: { error: false, message: '' },
   })
 
-  const formatUrl = (url: string) => {
-    if (!/^https?:\/\//i.test(url)) {
-      url = 'http://' + url
-    }
-    return url
-  }
-
   const handleIngest = async () => {
     setOpen(false)
 
@@ -159,28 +152,6 @@ export default function WebsiteIngestForm({
     }
 
     await new Promise((resolve) => setTimeout(resolve, 8000))
-  }
-
-  const formatUrlAndMatchRegex = (url: string) => {
-    // fullUrl always starts with http://. Is the starting place of the scrape.
-    // baseUrl is used to construct the match statement.
-
-    // Ensure the url starts with 'http://'
-    if (!/^https?:\/\//i.test(url)) {
-      url = 'http://' + url
-    }
-
-    // Extract the base url including the path
-    const baseUrl = (
-      url.replace(/^https?:\/\//i, '').split('?')[0] as string
-    ).replace(/\/$/, '') // Remove protocol (http/s), split at '?', and remove trailing slash
-
-    const matchRegex = `http?(s)://**${baseUrl}/**`
-
-    return {
-      fullUrl: baseUrl,
-      matchRegex: matchRegex,
-    }
   }
 
   useEffect(() => {
@@ -326,29 +297,16 @@ export default function WebsiteIngestForm({
       if (!url || !courseName) return null
       console.log('SCRAPING', url)
 
-      const fullUrl = formatUrl(url)
+      const response = await axios.post('/api/scrapeWeb', {
+        url,
+        courseName,
+        maxUrls,
+        scrapeStrategy,
+      })
 
-      const postParams = {
-        url: fullUrl,
-        courseName: courseName,
-        maxPagesToCrawl: maxUrls,
-        scrapeStrategy: scrapeStrategy,
-        match: formatUrlAndMatchRegex(fullUrl).matchRegex,
-        maxTokens: 2000000, // basically inf.
-      }
-      console.log(
-        'About to post to the web scraping endpoint, with params:',
-        postParams,
-      )
-
-      const response = await axios.post(
-        `https://crawlee-production.up.railway.app/crawl`,
-        {
-          params: postParams,
-        },
-      )
-      console.log('Response from web scraping endpoint:', response.data)
+      console.log('Response from Next.js API web scraping endpoint:', response.data)
       return response.data
+
     } catch (error: any) {
       console.error('Error during web scraping:', error)
 

--- a/src/pages/api/scrapeWeb.ts
+++ b/src/pages/api/scrapeWeb.ts
@@ -1,0 +1,84 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import axios from 'axios'
+
+interface ScrapeRequestBody {
+  url: string | null
+  courseName: string | null
+  maxUrls: number
+  scrapeStrategy: string
+}
+
+const formatUrl = (url: string) => {
+  if (!/^https?:\/\//i.test(url)) {
+    url = 'http://' + url
+  }
+  return url
+}
+
+const formatUrlAndMatchRegex = (url: string) => {
+  // fullUrl always starts with http://. Is the starting place of the scrape.
+  // baseUrl is used to construct the match statement.
+
+  // Ensure the url starts with 'http://'
+  if (!/^https?:\/\//i.test(url)) {
+    url = 'http://' + url
+  }
+
+  // Extract the base url including the path
+  const baseUrl = (
+    url.replace(/^https?:\/\//i, '').split('?')[0] as string
+  ).replace(/\/$/, '') // Remove protocol (http/s), split at '?', and remove trailing slash
+
+  const matchRegex = `http?(s)://**${baseUrl}/**`
+
+  return {
+    fullUrl: baseUrl,
+    matchRegex: matchRegex,
+  }
+}
+
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  const { url, courseName, maxUrls, scrapeStrategy } = req.body as ScrapeRequestBody
+
+  if (!url || !courseName) {
+    return res.status(400).json({ error: 'Missing required parameters' })
+  }
+
+  try {
+    const fullUrl = formatUrl(url)
+    const postParams = {
+      url: fullUrl,
+      courseName: courseName,
+      maxPagesToCrawl: maxUrls,
+      scrapeStrategy: scrapeStrategy,
+      match: formatUrlAndMatchRegex(fullUrl).matchRegex,
+      maxTokens: 2000000,
+    }
+
+    const crawleeApiUrl = process.env.CRAWLEE_API_URL;
+    if (!crawleeApiUrl) {
+      return res.status(500).json({ error: 'CRAWLEE_API_URL is not set' })
+    }
+    const response = await axios.post(
+      crawleeApiUrl,
+      { params: postParams }
+    )
+
+    return res.status(200).json(response.data)
+  } catch (error: any) {
+    console.error('Web scraping error:', error)
+
+    return res.status(500).json({
+      error: 'Web scraping failed. Please try again later.',
+      message: error.message,
+    })
+  }
+}


### PR DESCRIPTION
Need some help with testing.

- Create an endpoing /api/scrapeWeb
- Add env variable in infisical default to the production endpoint `https://crawlee-production.up.railway.app/crawl`; could be overwrite in dev deployment