### PR TITLE
fix logic of creating new keys

### DIFF
--- a/src/pages/api/chat-api/keys/generate.ts
+++ b/src/pages/api/chat-api/keys/generate.ts
@@ -58,9 +58,9 @@ export default async function generateKey(
       .from(apiKeys)
       .where(and(eq(apiKeys.email, email), eq(apiKeys.is_active, true)))
 
-    if (keys.length === 0) {
-      console.error('No existing API key found for user email:', email)
-      throw new Error('No existing API key found for user email')
+    if (!keys) {
+      console.error('Error retrieving API keys from DB');
+      throw new Error('Failed to fetch API keys');
     }
 
     console.log('Existing keys found:', keys.length)


### PR DESCRIPTION
**Fix: Allow new users to generate API keys**

This fixes a bug in the `generate API key` logic. Previously, the function would throw an error when failing to retrieve an existing key (see [lines 53–77](https://github.com/Center-for-AI-Innovation/uiuc-chat-frontend/blob/main/src/pages/api/chat-api/keys/generate.ts#L53-L77)), but did not handle the case where no key existed for a new user. The logic has been updated to allow key generation when no existing key is found.

You can verify the change by checking the database after key generation or rotation.

**To test:**
Visit `http://localhost:3000/test-aws-deployment/api` and click **Generate API Key** or **Rotate API Key**.

<img width="1512" alt="Pasted Graphic 24" src="https://github.com/user-attachments/assets/c5f7c78d-7f84-4ebc-bf95-91da49fb4753" />

---

Note: Delete API key won't work since it depends on #301 this PR

