### PR TITLE
Fix n8n bugs

### DIFF
--- a/src/components/UIUC-Components/N8NPage.tsx
+++ b/src/components/UIUC-Components/N8NPage.tsx
@@ -175,28 +175,32 @@ const MakeToolsPage = ({ course_name }: { course_name: string }) => {
   }
 
   useEffect(() => {
-    const getApiFromSupabase = async () => {
+    const getApiKey = async () => {
       try {
-        const response = await fetch(`/api/UIUC-api/getN8NapiFromSupabase`, {
+        const response = await fetch('/api/UIUC-api/getN8Napikey', {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
           },
-          body: JSON.stringify({
-            course_name: currentPageName,
-          }),
-        })
-        const data = await response.json()
-        setN8nApiKeyTextbox(data.api_key[0].n8n_api_key)
-        setN8nApiKey(data.api_key[0].n8n_api_key)
-        // return data.success
+          body: JSON.stringify({ course_name: currentPageName }),
+        });
+
+        const data = await response.json();
+        const apiKey = data.api_key?.[0]?.n8n_api_key;
+
+        if (apiKey) {
+          setN8nApiKeyTextbox(apiKey);
+          setN8nApiKey(apiKey);
+        } else {
+          console.warn('API key not found in response:', data);
+        }
       } catch (error) {
-        console.error('Error getting course data:', error)
-        // return false
+        console.error('Error getting course data:', error);
       }
-    }
-    getApiFromSupabase()
-  }, [course_name])
+    };
+
+    getApiKey();
+  }, [currentPageName]);
 
   useEffect(() => {
     const fetchData = async () => {

--- a/src/pages/api/UIUC-api/getN8Napikey.ts
+++ b/src/pages/api/UIUC-api/getN8Napikey.ts
@@ -9,7 +9,7 @@ type ApiResponse = {
   error?: any
 }
 
-export default async function getApiKeyByCourseName(
+export default async function getN8Napikey(
   req: NextApiRequest,
   res: NextApiResponse<ApiResponse>
 ) {
@@ -23,10 +23,9 @@ export default async function getApiKeyByCourseName(
     .select({ n8n_api_key: projects.n8n_api_key })
     .from(projects)
     .where(eq(projects.course_name, course_name))
-  // console.log('data from apifromsupa:', data)
   if (data.length === 0) {
     console.error('No API key found for course:', course_name)
-    return res.status(500).json({ success: false, error: 'No API key found for course' })
+    return res.status(404).json({ success: false, error: 'No API key found for course' })
   }
   return res.status(200).json({ success: true, api_key: data[0]?.n8n_api_key })
 }

--- a/src/pages/api/UIUC-api/tools/getN8nKeyFromProject.ts
+++ b/src/pages/api/UIUC-api/tools/getN8nKeyFromProject.ts
@@ -13,10 +13,8 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
       .select({ n8n_api_key: projects.n8n_api_key })
       .from(projects)
       .where(eq(projects.course_name, course_name))
-      .limit(1)
-
-    if (!data) {
-      return res.status(500).json({ error: 'No N8n API keys found for your project.' })
+    if (data.length === 0) {
+      return res.status(404).json({ error: 'No N8n API keys found for your project.' })
     }
     return res.status(200).json(data[0]?.n8n_api_key)
   } catch (error: any) {

--- a/src/pages/api/UIUC-api/tools/upsertN8nAPIKey.ts
+++ b/src/pages/api/UIUC-api/tools/upsertN8nAPIKey.ts
@@ -17,7 +17,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         course_name: course_name,
       })
       .onConflictDoUpdate({
-        target: [projects.course_name],
+        target: [projects.id],
         set: {
           n8n_api_key: n8n_api_key,
         },

--- a/src/pages/api/UIUC-api/tools/upsertN8nAPIKey.ts
+++ b/src/pages/api/UIUC-api/tools/upsertN8nAPIKey.ts
@@ -1,22 +1,15 @@
 import { db } from '~/db/dbClient'
-import { NextRequest, NextResponse } from 'next/server'
+import type { NextApiRequest, NextApiResponse } from 'next';
 import { projects } from '~/db/schema'
 
 
-export default async function handler(req: NextRequest, res: NextResponse) {
-  const requestBody = await req.json()
-  // console.log('upsertN8nAPIKey course_name and n8n_api_key:', requestBody)
-  const { course_name, n8n_api_key } = requestBody
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { course_name, n8n_api_key } = req.body;
   if (!course_name) {
-    return new NextResponse(
-      JSON.stringify({
-        success: false,
-        error: 'course_name is required',
-      }),
-      { status: 400 },
-    )
+    return res.status(400).json({ success: false, error: 'course_name is required' });
   }
-  try{
+
+  try {
     const result = await db
       .insert(projects)
       .values({
@@ -29,13 +22,10 @@ export default async function handler(req: NextRequest, res: NextResponse) {
           n8n_api_key: n8n_api_key,
         },
       })
-    console.log('upsertN8nAPIKey result:', result)
-    return new NextResponse(JSON.stringify({ success: true }), { status: 200 })
-  } catch (error: any) {
-    console.error('Error upserting N8n key to Supabase:', error)
-    return new NextResponse(JSON.stringify({ success: false, error: error }), {
-      status: 500,
-    })
+    console.log('upsertN8nAPIKey result:', result);
+    return res.status(200).json({ success: true });
+  } catch (error) {
+    console.error('Error upserting N8n key to Supabase:', error);
+    return res.status(500).json({ success: false, error: error });
   }
-
 }

--- a/src/pages/api/chat-api/chat.ts
+++ b/src/pages/api/chat-api/chat.ts
@@ -107,7 +107,7 @@ export default async function chat(
     isValidApiKey,
     authContext,
   }: { isValidApiKey: boolean; authContext: AuthContextProps } =
-    await validateApiKeyAndRetrieveData(api_key, course_name)
+    await validateApiKeyAndRetrieveData(api_key)
 
   const email = authContext.user?.profile.email
 

--- a/src/utils/functionCalling/handleFunctionCalling.ts
+++ b/src/utils/functionCalling/handleFunctionCalling.ts
@@ -516,6 +516,7 @@ export async function fetchTools(
         throw new Error("Failed to fetch Project's N8N API key")
       }
       api_key = await response.json()
+
     } catch (error) {
       console.error('Error fetching N8N API key:', error)
       return []
@@ -532,6 +533,7 @@ export async function fetchTools(
   const response = await fetch(
     `https://flask-production-751b.up.railway.app/getworkflows?api_key=${api_key}&limit=${limit}&pagination=${parsedPagination}`,
   )
+
   if (!response.ok) {
     // return res.status(response.status).json({ error: response.statusText })
     throw new Error(`Unable to fetch n8n tools: ${response.statusText}`)


### PR DESCRIPTION
### This PR addresses the following issues:

* Fixes mismatch between expected and actual response status
* Removes references to “Supabase” from function names for clarity
* Corrects incorrect `useEffect` logic in the frontend
* The `upsert` endpoint locates under `/pages/api`which requires to use Page Router instead of App Router
* `onConflictDoUpdate` change field `course_name` to `id` for uniqueness
---

### Additional Context:

Since project creation is handled in the backend, adding the N8N key **still injects it into the Supabase table.** 
However, key retrieval relies on the PostgreSQL `project` table—so this part won’t function correctly until the corresponding backend SQL logic is fully implemented.

```ts
export const createProject = async (
  project_name: string,
  project_description: string | undefined,
  project_owner_email: string,
): Promise<boolean> => {
  const requestBody = {
    project_name: project_name,
    project_description: project_description,
    project_owner_email: project_owner_email,
  }
  const url = 'https://flask-production-751b.up.railway.app/createProject'
  ...
```