### PR TITLE
Fix hardcoded backend URL references

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -111,7 +111,7 @@
         "@types/eslint": "^8.21.3",
         "@types/jsdom": "^21.1.1",
         "@types/lodash": "^4.17.9",
-        "@types/node": "^18.16.13",
+        "@types/node": "^18.19.112",
         "@types/prettier": "^2.7.2",
         "@types/react": "^18.0.28",
         "@types/react-dom": "^18.0.11",
@@ -7197,9 +7197,10 @@
       "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
     },
     "node_modules/@types/node": {
-      "version": "18.19.50",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.50.tgz",
-      "integrity": "sha512-xonK+NRrMBRtkL1hVCc3G+uXtjh1Al4opBLjqVmipe5ZAaBYWW6cNAiBVZ1BvmkBhep698rP3UM3aRAdSALuhg==",
+      "version": "18.19.112",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.112.tgz",
+      "integrity": "sha512-i+Vukt9POdS/MBI7YrrkkI5fMfwFtOjphSmt4WXYLfwqsfr6z/HdCx7LqT9M7JktGob8WNgj8nFB4TbGNE4Cog==",
+      "license": "MIT",
       "dependencies": {
         "undici-types": "~5.26.4"
       }

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "@types/eslint": "^8.21.3",
     "@types/jsdom": "^21.1.1",
     "@types/lodash": "^4.17.9",
-    "@types/node": "^18.16.13",
+    "@types/node": "^18.19.112",
     "@types/prettier": "^2.7.2",
     "@types/react": "^18.0.28",
     "@types/react-dom": "^18.0.11",

--- a/src/components/UIUC-Components/MITIngestForm.tsx
+++ b/src/components/UIUC-Components/MITIngestForm.tsx
@@ -44,7 +44,7 @@ export default function MITIngestForm({
       if (!url || !courseName || !localDir) return null
       console.log('calling downloadMITCourse')
       const response = await axios.get(
-        `https://flask-production-751b.up.railway.app/mit-download`,
+        `/api/UIUC-api/downloadMITCourse`,
         {
           params: {
             url: url,

--- a/src/components/UIUC-Components/MakeNewCoursePage.tsx
+++ b/src/components/UIUC-Components/MakeNewCoursePage.tsx
@@ -16,7 +16,7 @@ import {
 import { useMediaQuery } from '@mantine/hooks'
 import router from 'next/router'
 import { montserrat_heading, montserrat_paragraph } from 'fonts'
-import createProject from '~/pages/api/UIUC-api/createProject'
+import { createProject } from '~/pages/api/UIUC-api/createProject'
 import { callSetCourseMetadata } from '~/utils/apiUtils'
 import { CourseMetadata } from '~/types/courseMetadata'
 

--- a/src/components/UIUC-Components/MakeQueryAnalysisPage.tsx
+++ b/src/components/UIUC-Components/MakeQueryAnalysisPage.tsx
@@ -1149,7 +1149,7 @@ const CourseFilesList = ({ files }: CourseFilesListProps) => {
   const handleDelete = async (s3_path: string, course_name: string) => {
     try {
       const response = await axios.delete(
-        `https://flask-production-751b.up.railway.app/delete`,
+        `/api/UIUC-api/deleteDocument`,
         {
           params: { s3_path, course_name: 'ece120' },
         },

--- a/src/components/UIUC-Components/MakeQueryAnalysisPage.tsx
+++ b/src/components/UIUC-Components/MakeQueryAnalysisPage.tsx
@@ -1,7 +1,6 @@
 import Head from 'next/head'
 import { montserrat_heading, montserrat_paragraph } from 'fonts'
 // import { DropzoneS3Upload } from '~/components/UIUC-Components/Upload_S3'
-import { fetchPresignedUrl } from '~/utils/apiUtils'
 import {
   // Badge,
   // MantineProvider,
@@ -18,16 +17,13 @@ import {
   // Divider,
   type MantineTheme,
   Divider,
-  ActionIcon,
   // TextInput,
   // Tooltip,
   Select,
-  Group,
 } from '@mantine/core'
-import { DatePickerInput, type DateValue } from '@mantine/dates'
+import { DatePickerInput } from '@mantine/dates'
 // const rubik_puddles = Rubik_Puddles({ weight: '400', subsets: ['latin'] })
 import React, { useEffect, useState } from 'react'
-import axios from 'axios'
 import { useRouter } from 'next/router'
 import { LoadingSpinner } from './LoadingSpinner'
 import { downloadConversationHistory } from '../../pages/api/UIUC-api/downloadConvoHistory'
@@ -43,7 +39,6 @@ import {
   IconChartBar,
   IconMessage2,
   IconMessageCircle2,
-  IconInfoCircle,
   IconUsers,
   IconMinus,
   IconCalendar,
@@ -1109,179 +1104,18 @@ const MakeQueryAnalysisPage = ({ course_name }: { course_name: string }) => {
 }
 
 import {
-  IconAlertCircle,
-  IconAlertTriangle,
   IconCheck,
   IconCloudDownload,
-  IconDownload,
 } from '@tabler/icons-react'
 
 import { CannotEditCourse } from './CannotEditCourse'
 import { type CourseMetadata } from '~/types/courseMetadata'
-// import {CannotViewCourse} from './CannotViewCourse'
-
-interface CourseFile {
-  name: string
-  s3_path: string
-  course_name: string
-  readable_filename: string
-  type: string
-  url: string
-  base_url: string
-}
-
-interface CourseFilesListProps {
-  files: CourseFile[]
-}
-import { IconTrash } from '@tabler/icons-react'
-import { MainPageBackground } from './MainPageBackground'
 import { notifications } from '@mantine/notifications'
 import GlobalFooter from './GlobalFooter'
 import Navbar from './navbars/Navbar'
 import Link from 'next/link'
-import { Separator } from 'tabler-icons-react'
-import { AnimatePresence, motion } from 'framer-motion'
 import NomicDocumentMap from './NomicDocumentsMap'
 
-const CourseFilesList = ({ files }: CourseFilesListProps) => {
-  const router = useRouter()
-  const { classes, theme } = useStyles()
-  const handleDelete = async (s3_path: string, course_name: string) => {
-    try {
-      const response = await axios.delete(
-        `/api/UIUC-api/deleteDocument`,
-        {
-          params: { s3_path, course_name: 'ece120' },
-        },
-      )
-      // Handle successful deletion, show a success message
-      showToastOnFileDeleted(theme)
-      // Refresh the page
-      await router.push(router.asPath)
-    } catch (error) {
-      console.error(error)
-      // Show error message
-      showToastOnFileDeleted(theme, true)
-    }
-  }
-
-  return (
-    <div
-      className="mx-auto w-full justify-center rounded-md  bg-violet-100 p-5 shadow-md" // bg-violet-100
-      style={{ marginTop: '-1rem', backgroundColor: '#0F1116' }}
-    >
-      <ul role="list" className="grid grid-cols-2 gap-4">
-        {files.map((file, index) => (
-          <li
-            key={file.s3_path}
-            className="hover:shadow-xs flex items-center justify-between gap-x-6 rounded-xl bg-violet-300 py-4 pl-4 pr-1 transition duration-200 ease-in-out hover:bg-violet-200 hover:shadow-violet-200"
-            onMouseEnter={(e) => {
-              // Removed this because it causes the UI to jump around on mouse enter.
-              // e.currentTarget.style.border = 'solid 1.5px'
-              e.currentTarget.style.borderColor = theme.colors.violet[8]
-            }}
-            onMouseLeave={(e) => {
-              // e.currentTarget.style.border = 'solid 1.5px'
-            }}
-          >
-            {/* Conditionally show link in small text if exists */}
-            {file.url ? (
-              <div
-                className="min-w-0 flex-auto"
-                style={{
-                  maxWidth: '100%',
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis',
-                  whiteSpace: 'nowrap',
-                }}
-              >
-                <a href={file.url} target="_blank" rel="noopener noreferrer">
-                  <p className="truncate text-xl font-semibold leading-6 text-gray-800">
-                    {file.readable_filename}
-                  </p>
-                  <p className="mt-1 truncate text-xs leading-5 text-gray-600">
-                    {file.url || ''}
-                  </p>
-                </a>
-              </div>
-            ) : (
-              <div
-                className="min-w-0 flex-auto"
-                style={{
-                  maxWidth: '80%',
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis',
-                  whiteSpace: 'nowrap',
-                }}
-              >
-                <p className="text-xl font-semibold leading-6 text-gray-800">
-                  {file.readable_filename}
-                </p>
-                {/* SMALL LOWER TEXT FOR FILES IN LIST */}
-                {/* <p className="mt-1 truncate text-xs leading-5 text-gray-600">
-                  {file.course_name}
-                </p> */}
-              </div>
-            )}
-            <div className="me-4 flex justify-end space-x-2">
-              {/* Download button */}
-              <button
-                onClick={() =>
-                  fetchPresignedUrl(file.s3_path, GetCurrentPageName()).then(
-                    (url) => {
-                      window.open(url as string, '_blank')
-                    },
-                  )
-                }
-                className="btn-circle btn cursor-pointer items-center justify-center border-0 bg-transparent transition duration-200 ease-in-out"
-                // style={{ outline: 'solid 1px', outlineColor: 'white' }}
-                onMouseEnter={(e) => {
-                  e.currentTarget.style.backgroundColor = theme.colors.grape[8]
-                  ;(e.currentTarget.children[0] as HTMLElement).style.color =
-                    theme.colorScheme === 'dark'
-                      ? theme.colors.gray[2]
-                      : theme.colors.gray[1]
-                }}
-                onMouseLeave={(e) => {
-                  e.currentTarget.style.backgroundColor = 'transparent'
-                  ;(e.currentTarget.children[0] as HTMLElement).style.color =
-                    theme.colors.gray[8]
-                }}
-              >
-                <IconDownload className="h-5 w-5 text-gray-800" />
-              </button>
-              {/* Delete button */}
-              <button
-                onClick={() =>
-                  handleDelete(
-                    file.s3_path as string,
-                    file.course_name as string,
-                  )
-                }
-                className="btn-circle btn cursor-pointer items-center justify-center border-0 bg-transparent transition duration-200 ease-in-out"
-                // style={{ outline: 'solid 1px', outlineColor: theme.white }}
-                onMouseEnter={(e) => {
-                  e.currentTarget.style.backgroundColor = theme.colors.grape[8]
-                  ;(e.currentTarget.children[0] as HTMLElement).style.color =
-                    theme.colorScheme === 'dark'
-                      ? theme.colors.gray[2]
-                      : theme.colors.gray[1]
-                }}
-                onMouseLeave={(e) => {
-                  e.currentTarget.style.backgroundColor = 'transparent'
-                  ;(e.currentTarget.children[0] as HTMLElement).style.color =
-                    theme.colors.red[6]
-                }}
-              >
-                <IconTrash className="h-5 w-5 text-red-600" />
-              </button>
-            </div>
-          </li>
-        ))}
-      </ul>
-    </div>
-  )
-}
 
 async function fetchCourseMetadata(course_name: string) {
   try {

--- a/src/components/UIUC-Components/ProjectFilesTable.tsx
+++ b/src/components/UIUC-Components/ProjectFilesTable.tsx
@@ -295,9 +295,8 @@ export function ProjectFilesTable({
   const deleteDocumentMutation = useMutation({
     mutationFn: async (recordsToDelete: CourseDocument[]) => {
       console.debug('Deleting records:', recordsToDelete)
-      const API_URL = 'https://flask-production-751b.up.railway.app'
       const deletePromises = recordsToDelete.map((record) =>
-        axios.delete(`${API_URL}/delete`, {
+        axios.delete(`/api/UIUC-api/deleteDocument`, {
           params: {
             course_name: record.course_name,
             s3_path: record.s3_path,

--- a/src/components/UIUC-Components/WebScrape.tsx
+++ b/src/components/UIUC-Components/WebScrape.tsx
@@ -330,7 +330,7 @@ export const WebScrape = ({
       if (!url || !courseName || !localDir) return null
       console.log('calling downloadMITCourse')
       const response = await axios.get(
-        `https://flask-production-751b.up.railway.app/mit-download`,
+        `/api/UIUC-api/downloadMITCourse`,
         {
           params: {
             url: url,

--- a/src/pages/[course_name]/tools.tsx
+++ b/src/pages/[course_name]/tools.tsx
@@ -48,7 +48,7 @@ const ToolsPage: NextPage = () => {
       const data = await response.json()
       if (data) {
         const response = await fetch(
-          `https://flask-production-751b.up.railway.app/getAll?course_name=${course_name}`,
+          `/api/UIUC-api/getAllCourseData?course_name=${course_name}`,
         )
         const data = await response.json()
         const courseData = data.distinct_files

--- a/src/pages/api/UIUC-api/createProject.ts
+++ b/src/pages/api/UIUC-api/createProject.ts
@@ -1,37 +1,74 @@
-export const createProject = async (
-  project_name: string,
-  project_description: string | undefined,
-  project_owner_email: string,
-): Promise<boolean> => {
+export default async function handler(req: any, res: any) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  const { project_name, project_description, project_owner_email } = req.body
+
+  if (!project_name || !project_owner_email) {
+    return res.status(400).json({ 
+      error: 'project_name and project_owner_email are required' 
+    })
+  }
+
   const requestBody = {
     project_name: project_name,
     project_description: project_description,
     project_owner_email: project_owner_email,
   }
-  const url = 'https://flask-production-751b.up.railway.app/createProject'
 
   try {
-    const response = await fetch(url, {
+    const response = await fetch(`${process.env.RAILWAY_URL}/createProject`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
       },
       body: JSON.stringify(requestBody),
     })
+    
     if (!response.ok) {
-      console.error(
-        'Failed to create the project. Err status:',
-        response.status,
-      )
-      throw new Error(
-        'Failed to create the project. Err status:' + response.status,
-      )
+      console.error('Failed to create the project. Err status:', response.status)
+      return res.status(response.status).json({ 
+        error: `Failed to create the project. Status: ${response.status}` 
+      })
     }
+    
+    return res.status(200).json({ success: true })
+  } catch (error) {
+    console.error('Error creating project:', error)
+    return res.status(500).json({ 
+      error: 'Internal server error while creating project' 
+    })
+  }
+}
+
+// Helper function for backward compatibility
+export const createProject = async (
+  project_name: string,
+  project_description: string | undefined,
+  project_owner_email: string,
+): Promise<boolean> => {
+  try {
+    const response = await fetch('/api/UIUC-api/createProject', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        project_name,
+        project_description,
+        project_owner_email,
+      }),
+    })
+    
+    if (!response.ok) {
+      console.error('Failed to create the project. Err status:', response.status)
+      return false
+    }
+    
     return true
   } catch (error) {
     console.error(error)
     return false
   }
 }
-
-export default createProject

--- a/src/pages/api/UIUC-api/createProject.ts
+++ b/src/pages/api/UIUC-api/createProject.ts
@@ -1,3 +1,5 @@
+import { getBackendUrl } from '~/utils/apiUtils'
+
 export default async function handler(req: any, res: any) {
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' })
@@ -18,7 +20,7 @@ export default async function handler(req: any, res: any) {
   }
 
   try {
-    const response = await fetch(`${process.env.RAILWAY_URL}/createProject`, {
+    const response = await fetch(`${getBackendUrl()}/createProject`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/src/pages/api/UIUC-api/deleteDocument.ts
+++ b/src/pages/api/UIUC-api/deleteDocument.ts
@@ -1,0 +1,48 @@
+export default async function handler(req: any, res: any) {
+  if (req.method !== 'DELETE') {
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  const { course_name, s3_path, url } = req.query
+
+  if (!course_name) {
+    return res.status(400).json({ 
+      error: 'course_name parameter is required' 
+    })
+  }
+
+  if (!s3_path && !url) {
+    return res.status(400).json({ 
+      error: 's3_path or url parameter is required' 
+    })
+  }
+
+  try {
+    const params = new URLSearchParams()
+    params.append('course_name', course_name)
+    if (s3_path) params.append('s3_path', s3_path)
+    if (url) params.append('url', url)
+
+    const response = await fetch(
+      `${process.env.RAILWAY_URL}/delete?${params.toString()}`,
+      {
+        method: 'DELETE',
+      }
+    )
+
+    if (!response.ok) {
+      console.error('Failed to delete document. Err status:', response.status)
+      return res.status(response.status).json({ 
+        error: `Failed to delete document. Status: ${response.status}` 
+      })
+    }
+
+    const data = await response.json()
+    return res.status(200).json(data)
+  } catch (error) {
+    console.error('Error deleting document:', error)
+    return res.status(500).json({ 
+      error: 'Internal server error while deleting document' 
+    })
+  }
+}

--- a/src/pages/api/UIUC-api/deleteDocument.ts
+++ b/src/pages/api/UIUC-api/deleteDocument.ts
@@ -1,3 +1,5 @@
+import { getBackendUrl } from '~/utils/apiUtils'
+
 export default async function handler(req: any, res: any) {
   if (req.method !== 'DELETE') {
     return res.status(405).json({ error: 'Method not allowed' })
@@ -24,7 +26,7 @@ export default async function handler(req: any, res: any) {
     if (url) params.append('url', url)
 
     const response = await fetch(
-      `${process.env.RAILWAY_URL}/delete?${params.toString()}`,
+      `${getBackendUrl()}/delete?${params.toString()}`,
       {
         method: 'DELETE',
       }

--- a/src/pages/api/UIUC-api/downloadConvoHistory.ts
+++ b/src/pages/api/UIUC-api/downloadConvoHistory.ts
@@ -1,49 +1,103 @@
 import axios from 'axios'
+import { type NextApiRequest, type NextApiResponse } from 'next'
 
 interface DownloadResult {
   message: string
 }
 
+// Server-side API route handler
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  const { course_name } = req.query
+
+  if (!course_name || typeof course_name !== 'string') {
+    return res.status(400).json({ 
+      error: 'course_name parameter is required' 
+    })
+  }
+
+  try {
+    const response = await axios.get(
+      `${process.env.RAILWAY_URL}/export-convo-history?course_name=${course_name}`,
+      { responseType: 'blob' },
+    )
+
+    // Check content type from response headers
+    const contentType = response.headers['content-type']
+    
+    if (contentType === 'application/json') {
+      // Handle JSON response (S3 download case)
+      // In Node.js, response.data is a Buffer when responseType is 'blob'
+      const jsonText = response.data.toString('utf-8')
+      const jsonData = JSON.parse(jsonText)
+      
+      if (jsonData.response === 'Download from S3') {
+        return res.status(200).json({
+          message: "We are gathering your large conversation history, you'll receive an email with a download link shortly.",
+        })
+      } else {
+        return res.status(200).json({
+          message: 'Your conversation history is ready for download.',
+        })
+      }
+    } else if (contentType === 'application/zip') {
+      // Handle ZIP file response - response.data is already a Buffer in Node.js
+      res.setHeader('Content-Type', 'application/zip')
+      res.setHeader('Content-Disposition', `attachment; filename="${course_name.substring(0, 10)}-convos.zip"`)
+      return res.status(200).send(response.data)
+    } else {
+      // Handle unexpected content types
+      console.log('Unexpected content type:', contentType)
+      return res.status(500).json({ message: `Unexpected response format from backend: ${contentType}` })
+    }
+  } catch (error) {
+    console.error('Error exporting conversation history:', error)
+    return res.status(500).json({ message: 'Error exporting conversation history.' })
+  }
+}
+
+// Client-side function for downloading conversation history
 export const downloadConversationHistory = async (
   courseName: string,
 ): Promise<DownloadResult> => {
   try {
-    const response = await axios.get(
-      `${process.env.RAILWAY_URL}/export-convo-history?course_name=${courseName}`,
-      { responseType: 'blob' },
+    const response = await fetch(
+      `/api/UIUC-api/downloadConvoHistory?course_name=${courseName}`,
+      { method: 'GET' }
     )
 
-    if (response.headers['content-type'] === 'application/json') {
-      return new Promise((resolve, reject) => {
-        const reader = new FileReader()
-        reader.onload = function () {
-          const jsonData = JSON.parse(reader.result as string)
-          if (jsonData.response === 'Download from S3') {
-            resolve({
-              message:
-                "We are gathering your large conversation history, you'll receive an email with a download link shortly.",
-            })
-          } else {
-            resolve({
-              message: 'Your conversation history is ready for download.',
-            })
-          }
-        }
-        reader.onerror = reject
-        reader.readAsText(new Blob([response.data]))
-      })
-    } else if (response.headers['content-type'] === 'application/zip') {
-      const url = window.URL.createObjectURL(new Blob([response.data]))
+    if (!response.ok) {
+      const errorData = await response.json()
+      return { message: errorData.message || 'Error downloading conversation history.' }
+    }
+
+    // Check if it's a JSON response or a file download
+    const contentType = response.headers.get('content-type')
+    
+    if (contentType && contentType.includes('application/json')) {
+      // Handle JSON response (S3 download case or error)
+      const data = await response.json()
+      return { message: data.message }
+    } else if (contentType && contentType.includes('application/zip')) {
+      // Handle ZIP file download
+      const blob = await response.blob()
+      const url = window.URL.createObjectURL(blob)
       const link = document.createElement('a')
       link.href = url
       link.setAttribute('download', courseName.substring(0, 10) + '-convos.zip')
       document.body.appendChild(link)
       link.click()
+      document.body.removeChild(link)
+      window.URL.revokeObjectURL(url)
       return { message: 'Downloading now, check your downloads.' }
+    } else {
+      return { message: 'Unexpected response format.' }
     }
   } catch (error) {
-    console.error('Error exporting documents:', error)
-    return { message: 'Error exporting documents.' }
+    console.error('Error downloading conversation history:', error)
+    return { message: 'Error downloading conversation history.' }
   }
-  return { message: 'Unexpected error occurred.' }
 }

--- a/src/pages/api/UIUC-api/downloadConvoHistory.ts
+++ b/src/pages/api/UIUC-api/downloadConvoHistory.ts
@@ -1,5 +1,6 @@
 import axios from 'axios'
 import { type NextApiRequest, type NextApiResponse } from 'next'
+import { getBackendUrl } from '~/utils/apiUtils'
 
 interface DownloadResult {
   message: string
@@ -21,7 +22,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   try {
     const response = await axios.get(
-      `${process.env.RAILWAY_URL}/export-convo-history?course_name=${course_name}`,
+      `${getBackendUrl()}/export-convo-history?course_name=${course_name}`,
       { responseType: 'blob' },
     )
 

--- a/src/pages/api/UIUC-api/downloadConvoHistory.ts
+++ b/src/pages/api/UIUC-api/downloadConvoHistory.ts
@@ -9,7 +9,7 @@ export const downloadConversationHistory = async (
 ): Promise<DownloadResult> => {
   try {
     const response = await axios.get(
-      `https://flask-production-751b.up.railway.app/export-convo-history?course_name=${courseName}`,
+      `${process.env.RAILWAY_URL}/export-convo-history?course_name=${courseName}`,
       { responseType: 'blob' },
     )
 

--- a/src/pages/api/UIUC-api/downloadConvoHistoryUser.ts
+++ b/src/pages/api/UIUC-api/downloadConvoHistoryUser.ts
@@ -13,7 +13,7 @@ export const downloadConversationHistoryUser = async (
   )
   try {
     const response = await axios.get(
-      `https://flask-production-751b.up.railway.app/export-convo-history-user?user_email=${userEmail}&project_name=${projectName}`,
+      `${process.env.RAILWAY_URL}/export-convo-history-user?user_email=${userEmail}&project_name=${projectName}`,
       { responseType: 'blob' },
     )
     console.log('Received response:', response)

--- a/src/pages/api/UIUC-api/downloadConvoHistoryUser.ts
+++ b/src/pages/api/UIUC-api/downloadConvoHistoryUser.ts
@@ -1,4 +1,5 @@
 import axios from 'axios'
+import { getBackendUrl } from '~/utils/apiUtils'
 
 interface DownloadResult {
   message: string
@@ -13,7 +14,7 @@ export const downloadConversationHistoryUser = async (
   )
   try {
     const response = await axios.get(
-      `${process.env.RAILWAY_URL}/export-convo-history-user?user_email=${userEmail}&project_name=${projectName}`,
+      `${getBackendUrl()}/export-convo-history-user?user_email=${userEmail}&project_name=${projectName}`,
       { responseType: 'blob' },
     )
     console.log('Received response:', response)

--- a/src/pages/api/UIUC-api/downloadMITCourse.ts
+++ b/src/pages/api/UIUC-api/downloadMITCourse.ts
@@ -1,0 +1,34 @@
+export default async function handler(req: any, res: any) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  const { url, course_name, local_dir } = req.query
+
+  if (!url || !course_name || !local_dir) {
+    return res.status(400).json({ 
+      error: 'url, course_name, and local_dir parameters are required' 
+    })
+  }
+
+  try {
+    const response = await fetch(
+      `${process.env.RAILWAY_URL}/mit-download?url=${encodeURIComponent(url)}&course_name=${encodeURIComponent(course_name)}&local_dir=${encodeURIComponent(local_dir)}`,
+    )
+
+    if (!response.ok) {
+      console.error('Failed to download MIT course. Err status:', response.status)
+      return res.status(response.status).json({ 
+        error: `Failed to download MIT course. Status: ${response.status}` 
+      })
+    }
+
+    const data = await response.json()
+    return res.status(200).json(data)
+  } catch (error) {
+    console.error('Error downloading MIT course:', error)
+    return res.status(500).json({ 
+      error: 'Internal server error while downloading MIT course' 
+    })
+  }
+}

--- a/src/pages/api/UIUC-api/downloadMITCourse.ts
+++ b/src/pages/api/UIUC-api/downloadMITCourse.ts
@@ -1,3 +1,5 @@
+import { getBackendUrl } from '~/utils/apiUtils'
+
 export default async function handler(req: any, res: any) {
   if (req.method !== 'GET') {
     return res.status(405).json({ error: 'Method not allowed' })
@@ -13,7 +15,7 @@ export default async function handler(req: any, res: any) {
 
   try {
     const response = await fetch(
-      `${process.env.RAILWAY_URL}/mit-download?url=${encodeURIComponent(url)}&course_name=${encodeURIComponent(course_name)}&local_dir=${encodeURIComponent(local_dir)}`,
+      `${getBackendUrl()}/mit-download?url=${encodeURIComponent(url)}&course_name=${encodeURIComponent(course_name)}&local_dir=${encodeURIComponent(local_dir)}`,
     )
 
     if (!response.ok) {

--- a/src/pages/api/UIUC-api/exportAllDocuments.ts
+++ b/src/pages/api/UIUC-api/exportAllDocuments.ts
@@ -1,5 +1,6 @@
 import axios from 'axios'
 import { type NextApiRequest, type NextApiResponse } from 'next'
+import { getBackendUrl } from '~/utils/apiUtils'
 
 interface ExportResult {
   message: string
@@ -22,7 +23,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   try {
     const response = await axios.get(
-      `${process.env.RAILWAY_URL}/exportDocuments?course_name=${course_name}`,
+      `${getBackendUrl()}/exportDocuments?course_name=${course_name}`,
       { responseType: 'blob' },
     )
 

--- a/src/pages/api/UIUC-api/exportAllDocuments.ts
+++ b/src/pages/api/UIUC-api/exportAllDocuments.ts
@@ -9,7 +9,7 @@ export const handleExport = async (
 ): Promise<ExportResult> => {
   try {
     const API_URL =
-      'https://flask-production-751b.up.railway.app/exportDocuments'
+      `${process.env.RAILWAY_URL}/exportDocuments`
     const response = await axios.get(`${API_URL}?course_name=${course_name}`, {
       responseType: 'blob',
     })

--- a/src/pages/api/UIUC-api/exportAllDocuments.ts
+++ b/src/pages/api/UIUC-api/exportAllDocuments.ts
@@ -1,51 +1,106 @@
 import axios from 'axios'
+import { type NextApiRequest, type NextApiResponse } from 'next'
+
 interface ExportResult {
   message: string
   s3_path?: string
 }
 
+// Server-side API route handler
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  const { course_name } = req.query
+
+  if (!course_name || typeof course_name !== 'string') {
+    return res.status(400).json({ 
+      error: 'course_name parameter is required' 
+    })
+  }
+
+  try {
+    const response = await axios.get(
+      `${process.env.RAILWAY_URL}/exportDocuments?course_name=${course_name}`,
+      { responseType: 'blob' },
+    )
+
+    // Check content type from response headers
+    const contentType = response.headers['content-type']
+    
+    if (contentType === 'application/json') {
+      // Handle JSON response (S3 download case)
+      // In Node.js, response.data is a Buffer when responseType is 'blob'
+      const jsonText = response.data.toString('utf-8')
+      const jsonData = JSON.parse(jsonText)
+      console.log(jsonData)
+      
+      if (jsonData.response === 'Download from S3') {
+        return res.status(200).json({
+          message: 'We have started gathering your documents, you will receive an email shortly.',
+          s3_path: jsonData.s3_path,
+        })
+      } else {
+        return res.status(200).json({ 
+          message: 'Your documents are ready for download.' 
+        })
+      }
+    } else if (contentType === 'application/zip') {
+      // Handle ZIP file response - response.data is already a Buffer in Node.js
+      res.setHeader('Content-Type', 'application/zip')
+      res.setHeader('Content-Disposition', `attachment; filename="${course_name}_documents.zip"`)
+      return res.status(200).send(response.data)
+    } else {
+      // Handle unexpected content types
+      console.log('Unexpected content type:', contentType)
+      return res.status(500).json({ message: `Unexpected response format from backend: ${contentType}` })
+    }
+  } catch (error) {
+    console.error('Error exporting documents:', error)
+    return res.status(500).json({ message: 'Error exporting documents.' })
+  }
+}
+
+// Client-side function for exporting documents
 export const handleExport = async (
   course_name: string,
 ): Promise<ExportResult> => {
   try {
-    const API_URL =
-      `${process.env.RAILWAY_URL}/exportDocuments`
-    const response = await axios.get(`${API_URL}?course_name=${course_name}`, {
-      responseType: 'blob',
-    })
+    const response = await fetch(
+      `/api/UIUC-api/exportAllDocuments?course_name=${course_name}`,
+      { method: 'GET' }
+    )
 
-    if (response.headers['content-type'] === 'application/json') {
-      return new Promise((resolve, reject) => {
-        const reader = new FileReader()
-        reader.onload = function () {
-          const jsonData = JSON.parse(reader.result as string)
-          console.log(jsonData)
-          if (jsonData.response === 'Download from S3') {
-            resolve({
-              message:
-                'We have started gathering your documents, you will receive an email shortly.',
-              s3_path: jsonData.s3_path,
-            })
-          } else {
-            // Handle other JSON responses appropriately
-            resolve({ message: 'Your documents are ready for download.' })
-          }
-        }
-        reader.onerror = reject
-        reader.readAsText(new Blob([response.data]))
-      })
-    } else if (response.headers['content-type'] === 'application/zip') {
-      const url = window.URL.createObjectURL(new Blob([response.data]))
+    if (!response.ok) {
+      const errorData = await response.json()
+      return { message: errorData.message || 'Error exporting documents.' }
+    }
+
+    // Check if it's a JSON response or a file download
+    const contentType = response.headers.get('content-type')
+    
+    if (contentType && contentType.includes('application/json')) {
+      // Handle JSON response (S3 download case or error)
+      const data = await response.json()
+      return { message: data.message, s3_path: data.s3_path }
+    } else if (contentType && contentType.includes('application/zip')) {
+      // Handle ZIP file download
+      const blob = await response.blob()
+      const url = window.URL.createObjectURL(blob)
       const link = document.createElement('a')
       link.href = url
       link.setAttribute('download', course_name + '_documents.zip')
       document.body.appendChild(link)
       link.click()
+      document.body.removeChild(link)
+      window.URL.revokeObjectURL(url)
       return { message: 'Downloading now, check your downloads.' }
+    } else {
+      return { message: 'Unexpected response format.' }
     }
   } catch (error) {
     console.error('Error exporting documents:', error)
     return { message: 'Error exporting documents.' }
   }
-  return { message: 'Unexpected error occurred.' }
 }

--- a/src/pages/api/UIUC-api/getAllCourseData.ts
+++ b/src/pages/api/UIUC-api/getAllCourseData.ts
@@ -1,0 +1,32 @@
+export default async function handler(req: any, res: any) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  const { course_name } = req.query
+
+  if (!course_name || typeof course_name !== 'string') {
+    return res.status(400).json({ error: 'course_name parameter is required' })
+  }
+
+  try {
+    const response = await fetch(
+      `${process.env.RAILWAY_URL}/getAll?course_name=${course_name}`,
+    )
+
+    if (!response.ok) {
+      console.error('Failed to fetch course data. Err status:', response.status)
+      return res.status(response.status).json({ 
+        error: `Failed to fetch course data. Status: ${response.status}` 
+      })
+    }
+
+    const data = await response.json()
+    return res.status(200).json(data)
+  } catch (error) {
+    console.error('Error fetching course data:', error)
+    return res.status(500).json({ 
+      error: 'Internal server error while fetching course data' 
+    })
+  }
+}

--- a/src/pages/api/UIUC-api/getAllCourseData.ts
+++ b/src/pages/api/UIUC-api/getAllCourseData.ts
@@ -1,3 +1,5 @@
+import { getBackendUrl } from '~/utils/apiUtils'
+
 export default async function handler(req: any, res: any) {
   if (req.method !== 'GET') {
     return res.status(405).json({ error: 'Method not allowed' })
@@ -11,7 +13,7 @@ export default async function handler(req: any, res: any) {
 
   try {
     const response = await fetch(
-      `${process.env.RAILWAY_URL}/getAll?course_name=${course_name}`,
+      `${getBackendUrl()}/getAll?course_name=${course_name}`,
     )
 
     if (!response.ok) {

--- a/src/pages/api/UIUC-api/getConversationStats.ts
+++ b/src/pages/api/UIUC-api/getConversationStats.ts
@@ -1,24 +1,14 @@
 // src/pages/api/UIUC-api/getConversationStats.ts
-import { type NextRequest, NextResponse } from 'next/server'
 
-export const runtime = 'edge'
-
-export default async function handler(req: NextRequest, res: NextResponse) {
-  const course_name = req.nextUrl.searchParams.get('course_name')
-  const from_date = req.nextUrl.searchParams.get('from_date')
-  const to_date = req.nextUrl.searchParams.get('to_date')
+export default async function handler(req: any, res: any) {
+  const { course_name, from_date, to_date } = req.query
 
   if (!course_name) {
-    return NextResponse.json(
-      { error: 'Missing required course_name parameter' },
-      { status: 400 },
-    )
+    return res.status(400).json({ error: 'Missing required course_name parameter' })
   }
 
   try {
-    const url = new URL(
-      'https://flask-production-751b.up.railway.app/getConversationStats',
-    )
+    const url = new URL(`${process.env.RAILWAY_URL}/getConversationStats`)
     url.searchParams.append('course_name', course_name)
     if (from_date) url.searchParams.append('from_date', from_date)
     if (to_date) url.searchParams.append('to_date', to_date)
@@ -31,13 +21,10 @@ export default async function handler(req: NextRequest, res: NextResponse) {
 
     const data = await response.json()
 
-    return NextResponse.json(data)
+    return res.status(200).json(data)
   } catch (error) {
     console.error('Error fetching questions per day:', error)
-    return NextResponse.json(
-      { error: 'Failed to fetch questions per day' },
-      { status: 500 },
-    )
+    return res.status(500).json({ error: 'Failed to fetch questions per day' })
   }
 }
 

--- a/src/pages/api/UIUC-api/getConversationStats.ts
+++ b/src/pages/api/UIUC-api/getConversationStats.ts
@@ -1,5 +1,7 @@
 // src/pages/api/UIUC-api/getConversationStats.ts
 
+import { getBackendUrl } from '~/utils/apiUtils'
+
 export default async function handler(req: any, res: any) {
   const { course_name, from_date, to_date } = req.query
 
@@ -8,7 +10,7 @@ export default async function handler(req: any, res: any) {
   }
 
   try {
-    const url = new URL(`${process.env.RAILWAY_URL}/getConversationStats`)
+    const url = new URL(`${getBackendUrl()}/getConversationStats`)
     url.searchParams.append('course_name', course_name)
     if (from_date) url.searchParams.append('from_date', from_date)
     if (to_date) url.searchParams.append('to_date', to_date)

--- a/src/pages/api/UIUC-api/getDocsForMaterials.ts
+++ b/src/pages/api/UIUC-api/getDocsForMaterials.ts
@@ -3,7 +3,7 @@ import { supabase } from '~/utils/supabaseClient'
 
 export const runtime = 'edge'
 
-export const getCourseDocumentsHandler = async (
+const getCourseDocumentsHandler = async (
   req: NextApiRequest,
   res: NextApiResponse,
 ) => {
@@ -63,3 +63,5 @@ export const getCourseDocuments = async (
     return null
   }
 }
+
+export default getCourseDocumentsHandler

--- a/src/pages/api/UIUC-api/getModelUsageCounts.ts
+++ b/src/pages/api/UIUC-api/getModelUsageCounts.ts
@@ -1,3 +1,5 @@
+import { getBackendUrl } from '~/utils/apiUtils'
+
 interface ModelUsage {
   model_name: string
   count: number
@@ -13,7 +15,7 @@ export default async function handler(req: any, res: any) {
 
   try {
     const response = await fetch(
-      `${process.env.RAILWAY_URL}/getModelUsageCounts?project_name=${project_name}`,
+      `${getBackendUrl()}/getModelUsageCounts?project_name=${project_name}`,
     )
 
     if (!response.ok) {

--- a/src/pages/api/UIUC-api/getModelUsageCounts.ts
+++ b/src/pages/api/UIUC-api/getModelUsageCounts.ts
@@ -1,48 +1,37 @@
-import { type NextRequest, NextResponse } from 'next/server'
-
 interface ModelUsage {
   model_name: string
   count: number
   percentage: number
 }
 
-export const runtime = 'edge'
-
-export default async function handler(req: NextRequest, res: NextResponse) {
-  const project_name = req.nextUrl.searchParams.get('project_name')
+export default async function handler(req: any, res: any) {
+  const { project_name } = req.query
 
   if (!project_name) {
-    return NextResponse.json(
-      { error: 'Missing required project_name parameter' },
-      { status: 400 },
-    )
+    return res.status(400).json({ error: 'Missing required project_name parameter' })
   }
 
   try {
     const response = await fetch(
-      `https://flask-production-751b.up.railway.app/getModelUsageCounts?project_name=${project_name}`,
+      `${process.env.RAILWAY_URL}/getModelUsageCounts?project_name=${project_name}`,
     )
 
     if (!response.ok) {
       const errorText = await response.text()
       console.error('Backend response not OK:', response.status, errorText)
-      return NextResponse.json(
-        { error: `Failed to fetch data: ${response.status} - ${errorText}` },
-        { status: response.status },
-      )
+      return res.status(response.status).json({ 
+        error: `Failed to fetch data: ${response.status} - ${errorText}` 
+      })
     }
 
     const data = (await response.json()) as ModelUsage[]
-    return NextResponse.json(data)
+    return res.status(200).json(data)
   } catch (error) {
     console.error('Error in handler:', error)
-    return NextResponse.json(
-      {
-        error: 'Failed to fetch model usage counts',
-        details: error instanceof Error ? error.message : String(error),
-      },
-      { status: 500 },
-    )
+    return res.status(500).json({
+      error: 'Failed to fetch model usage counts',
+      details: error instanceof Error ? error.message : String(error),
+    })
   }
 }
 

--- a/src/pages/api/UIUC-api/getN8nWorkflows.ts
+++ b/src/pages/api/UIUC-api/getN8nWorkflows.ts
@@ -1,4 +1,6 @@
-export default async function handler(req: any, res: any) {
+import { type NextApiRequest, type NextApiResponse } from 'next'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'GET') {
     return res.status(405).json({ error: 'Method not allowed' })
   }

--- a/src/pages/api/UIUC-api/getN8nWorkflows.ts
+++ b/src/pages/api/UIUC-api/getN8nWorkflows.ts
@@ -1,0 +1,31 @@
+export default async function handler(req: any, res: any) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  const { api_key, limit, pagination } = req.query
+
+  if (!api_key) {
+    return res.status(400).json({ error: 'api_key is required' })
+  }
+
+  try {
+    const response = await fetch(
+      `${process.env.RAILWAY_URL}/getworkflows?api_key=${api_key}&limit=${limit || 10}&pagination=${pagination || 'true'}`,
+    )
+
+    if (!response.ok) {
+      return res.status(response.status).json({ 
+        error: `Unable to fetch n8n tools: ${response.statusText}` 
+      })
+    }
+
+    const workflows = await response.json()
+    return res.status(200).json(workflows)
+  } catch (error) {
+    console.error('Error fetching N8N workflows:', error)
+    return res.status(500).json({ 
+      error: 'Internal server error while fetching N8N workflows' 
+    })
+  }
+}

--- a/src/pages/api/UIUC-api/getN8nWorkflows.ts
+++ b/src/pages/api/UIUC-api/getN8nWorkflows.ts
@@ -1,4 +1,5 @@
 import { type NextApiRequest, type NextApiResponse } from 'next'
+import { getBackendUrl } from '~/utils/apiUtils'
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'GET') {
@@ -13,7 +14,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   try {
     const response = await fetch(
-      `${process.env.RAILWAY_URL}/getworkflows?api_key=${api_key}&limit=${limit || 10}&pagination=${pagination || 'true'}`,
+      `${getBackendUrl()}/getworkflows?api_key=${api_key}&limit=${limit || 10}&pagination=${pagination || 'true'}`,
     )
 
     if (!response.ok) {

--- a/src/pages/api/UIUC-api/getProjectStats.ts
+++ b/src/pages/api/UIUC-api/getProjectStats.ts
@@ -1,41 +1,31 @@
 // src/pages/api/UIUC-api/getProjectStats.ts
-import { type NextRequest, NextResponse } from 'next/server'
 
-export const runtime = 'edge'
-
-export default async function handler(req: NextRequest, res: NextResponse) {
-  const project_name = req.nextUrl.searchParams.get('project_name')
+export default async function handler(req: any, res: any) {
+  const { project_name } = req.query
 
   if (!project_name) {
-    return NextResponse.json(
-      { error: 'Missing required project_name parameter' },
-      { status: 400 },
-    )
+    return res.status(400).json({ error: 'Missing required project_name parameter' })
   }
 
   try {
     const response = await fetch(
-      `https://flask-production-751b.up.railway.app/getProjectStats?project_name=${project_name}`,
+      `${process.env.RAILWAY_URL}/getProjectStats?project_name=${project_name}`,
     )
 
     if (!response.ok) {
-      return NextResponse.json(
-        { error: `Failed to fetch data: ${response.statusText}` },
-        { status: response.status },
-      )
+      return res.status(response.status).json({ 
+        error: `Failed to fetch data: ${response.statusText}` 
+      })
     }
 
     const data = await response.json()
-    return NextResponse.json(data)
+    return res.status(200).json(data)
   } catch (error) {
     console.error('Error fetching project stats:', error)
-    return NextResponse.json(
-      {
-        error: 'Failed to fetch project stats',
-        details: (error as Error).message,
-      },
-      { status: 500 },
-    )
+    return res.status(500).json({
+      error: 'Failed to fetch project stats',
+      details: (error as Error).message,
+    })
   }
 }
 

--- a/src/pages/api/UIUC-api/getProjectStats.ts
+++ b/src/pages/api/UIUC-api/getProjectStats.ts
@@ -1,4 +1,5 @@
 // src/pages/api/UIUC-api/getProjectStats.ts
+import { getBackendUrl } from '~/utils/apiUtils'
 
 export default async function handler(req: any, res: any) {
   const { project_name } = req.query
@@ -9,7 +10,7 @@ export default async function handler(req: any, res: any) {
 
   try {
     const response = await fetch(
-      `${process.env.RAILWAY_URL}/getProjectStats?project_name=${project_name}`,
+      `${getBackendUrl()}/getProjectStats?project_name=${project_name}`,
     )
 
     if (!response.ok) {

--- a/src/pages/api/UIUC-api/getWeeklyTrends.ts
+++ b/src/pages/api/UIUC-api/getWeeklyTrends.ts
@@ -1,3 +1,5 @@
+import { getBackendUrl } from '~/utils/apiUtils'
+
 export default async function handler(req: any, res: any) {
   const { project_name } = req.query
 
@@ -7,7 +9,7 @@ export default async function handler(req: any, res: any) {
 
   try {
     const response = await fetch(
-      `${process.env.RAILWAY_URL}/getWeeklyTrends?project_name=${project_name}`,
+      `${getBackendUrl()}/getWeeklyTrends?project_name=${project_name}`,
     )
 
     if (!response.ok) {

--- a/src/pages/api/UIUC-api/getWeeklyTrends.ts
+++ b/src/pages/api/UIUC-api/getWeeklyTrends.ts
@@ -1,40 +1,29 @@
-import { type NextRequest, NextResponse } from 'next/server'
-
-export const runtime = 'edge'
-
-export default async function handler(req: NextRequest) {
-  const project_name = req.nextUrl.searchParams.get('project_name')
+export default async function handler(req: any, res: any) {
+  const { project_name } = req.query
 
   if (!project_name) {
-    return NextResponse.json(
-      { error: 'Missing required project_name parameter' },
-      { status: 400 },
-    )
+    return res.status(400).json({ error: 'Missing required project_name parameter' })
   }
 
   try {
     const response = await fetch(
-      `https://flask-production-751b.up.railway.app/getWeeklyTrends?project_name=${project_name}`,
+      `${process.env.RAILWAY_URL}/getWeeklyTrends?project_name=${project_name}`,
     )
 
     if (!response.ok) {
-      return NextResponse.json(
-        { error: `Failed to fetch data: ${response.statusText}` },
-        { status: response.status },
-      )
+      return res.status(response.status).json({ 
+        error: `Failed to fetch data: ${response.statusText}` 
+      })
     }
 
     const data = await response.json()
-    return NextResponse.json(data)
+    return res.status(200).json(data)
   } catch (error) {
     console.error('Error fetching weekly trends:', error)
-    return NextResponse.json(
-      {
-        error: 'Failed to fetch weekly trends',
-        details: (error as Error).message,
-      },
-      { status: 500 },
-    )
+    return res.status(500).json({
+      error: 'Failed to fetch weekly trends',
+      details: (error as Error).message,
+    })
   }
 }
 

--- a/src/pages/api/UIUC-api/ingestCanvas.ts
+++ b/src/pages/api/UIUC-api/ingestCanvas.ts
@@ -1,4 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
+import { getBackendUrl } from '~/utils/apiUtils'
 
 const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   try {
@@ -25,7 +26,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
 
     // Send email to kastan alerting that he needs to approve a canvas course
     const sendEmailResponse = await fetch(
-      `${process.env.RAILWAY_URL}/send-transactional-email`,
+      `${getBackendUrl()}/send-transactional-email`,
       {
         method: 'POST',
         headers: {

--- a/src/pages/api/UIUC-api/ingestCanvas.ts
+++ b/src/pages/api/UIUC-api/ingestCanvas.ts
@@ -25,7 +25,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
 
     // Send email to kastan alerting that he needs to approve a canvas course
     const sendEmailResponse = await fetch(
-      `https://flask-production-751b.up.railway.app/send-transactional-email`,
+      `${process.env.RAILWAY_URL}/send-transactional-email`,
       {
         method: 'POST',
         headers: {

--- a/src/pages/api/UIUC-api/logConversationToSupabase.ts
+++ b/src/pages/api/UIUC-api/logConversationToSupabase.ts
@@ -1,7 +1,8 @@
-import { supabase } from '@/utils/supabaseClient'
-import { Content, Conversation } from '~/types/chat'
-import { RunTree } from 'langsmith'
 import { sanitizeForLogging } from '@/utils/sanitization'
+import { supabase } from '@/utils/supabaseClient'
+import { RunTree } from 'langsmith'
+import { Content, Conversation } from '~/types/chat'
+import { getBackendUrl } from '~/utils/apiUtils'
 
 export const config = {
   api: {
@@ -40,7 +41,7 @@ const logConversationToSupabase = async (req: any, res: any) => {
   // Send to our custom monitor
   try {
     const response = await fetch(
-      process.env.RAILWAY_URL + '/llm-monitor-message',
+      getBackendUrl() + '/llm-monitor-message',
       {
         method: 'POST',
         headers: {

--- a/src/pages/api/UIUC-api/runN8nFlow.ts
+++ b/src/pages/api/UIUC-api/runN8nFlow.ts
@@ -1,4 +1,5 @@
 import { type NextApiRequest, type NextApiResponse } from 'next'
+import { getBackendUrl } from '~/utils/apiUtils'
 
 // Common function to run N8N flow - can be used anywhere
 export const runN8nFlowBackend = async (
@@ -6,10 +7,7 @@ export const runN8nFlowBackend = async (
   name: string,
   data: any,
 ): Promise<any> => {
-  const backendUrl = process.env.RAILWAY_URL
-  if (!backendUrl) {
-    throw new Error('No backend URL configured. Please set RAILWAY_URL environment variable.')
-  }
+  const backendUrl = getBackendUrl()
 
   const controller = new AbortController()
   const timeoutId = setTimeout(() => controller.abort(), 30000)

--- a/src/pages/api/UIUC-api/runN8nFlow.ts
+++ b/src/pages/api/UIUC-api/runN8nFlow.ts
@@ -1,0 +1,61 @@
+export default async function handler(req: any, res: any) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  const { api_key, name, data } = req.body
+
+  if (!api_key || !name || !data) {
+    return res.status(400).json({ 
+      error: 'api_key, name, and data are required' 
+    })
+  }
+
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), 30000)
+
+  try {
+    const body = JSON.stringify({
+      api_key: api_key,
+      name: name,
+      data: data,
+    })
+
+    const response = await fetch(
+      `${process.env.RAILWAY_URL}/run_flow`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Cache-Control': 'no-cache',
+        },
+        body: body,
+        signal: controller.signal,
+      },
+    )
+
+    clearTimeout(timeoutId)
+
+    if (!response.ok) {
+      const errjson = await response.json()
+      console.error('Error calling n8n function:', errjson.error)
+      return res.status(response.status).json({ error: errjson.error })
+    }
+
+    const n8nResponse = await response.json()
+    return res.status(200).json(n8nResponse)
+  } catch (error: any) {
+    clearTimeout(timeoutId)
+    
+    if (error.name === 'AbortError') {
+      return res.status(408).json({ 
+        error: 'Request timed out after 30 seconds, try "Regenerate Response" button' 
+      })
+    }
+    
+    console.error('Error in runN8nFlow API:', error)
+    return res.status(500).json({ 
+      error: 'Internal server error while running N8N flow' 
+    })
+  }
+}

--- a/src/pages/api/UIUC-api/tools/activateWorkflow.ts
+++ b/src/pages/api/UIUC-api/tools/activateWorkflow.ts
@@ -1,5 +1,6 @@
 // ingest.ts
 import { NextApiRequest, NextApiResponse } from 'next'
+import { getBackendUrl } from '~/utils/apiUtils'
 
 const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   try {
@@ -16,7 +17,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     console.log('activate', activateCapitalized)
 
     const response = await fetch(
-      `${process.env.RAILWAY_URL}/switch_workflow?id=${id}&api_key=${api_key}&activate=${activateCapitalized}`,
+      `${getBackendUrl()}/switch_workflow?id=${id}&api_key=${api_key}&activate=${activateCapitalized}`,
     )
     if (!response.ok) {
       console.log('response not ok', response.text)

--- a/src/pages/api/UIUC-api/tools/testN8nAPI.ts
+++ b/src/pages/api/UIUC-api/tools/testN8nAPI.ts
@@ -1,5 +1,4 @@
-import axios from 'axios'
-import { NextRequest, NextResponse } from 'next/server'
+import { getBackendUrl } from '~/utils/apiUtils'
 
 // export const runtime = 'edge'
 
@@ -11,7 +10,7 @@ export default async function handler(req: any, res: any) {
   const limit = 1
 
   const response = await fetch(
-    `${process.env.RAILWAY_URL}/getworkflows?api_key=${n8nApiKey}&limit=${limit}&pagination=${parsedPagination}`,
+    `${getBackendUrl()}/getworkflows?api_key=${n8nApiKey}&limit=${limit}&pagination=${parsedPagination}`,
   )
 
   if (!response.ok) {

--- a/src/pages/api/getContexts.ts
+++ b/src/pages/api/getContexts.ts
@@ -1,5 +1,6 @@
 import { type NextApiRequest, type NextApiResponse } from 'next'
 import { type ContextWithMetadata } from '~/types/chat'
+import { getBackendUrl } from '~/utils/apiUtils'
 
 // Common function to fetch contexts from backend - can be used anywhere
 export const fetchContextsFromBackend = async (
@@ -8,10 +9,7 @@ export const fetchContextsFromBackend = async (
   token_limit = 4000,
   doc_groups: string[] = [],
 ): Promise<ContextWithMetadata[]> => {
-  const backendUrl = process.env.RAILWAY_URL
-  if (!backendUrl) {
-    throw new Error('No backend URL configured. Please set RAILWAY_URL environment variable.')
-  }
+  const backendUrl = getBackendUrl()
 
   const requestBody = {
     course_name: course_name,

--- a/src/pages/api/getContexts.ts
+++ b/src/pages/api/getContexts.ts
@@ -1,13 +1,18 @@
 import { ContextWithMetadata } from '~/types/chat'
 
+export default async function handler(req: any, res: any) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
 
+  const { course_name, search_query, token_limit = 4000, doc_groups = [] } = req.body
 
-export const fetchContexts = async (
-  course_name: string,
-  search_query: string,
-  token_limit = 4000,
-  doc_groups: string[] = [],
-): Promise<ContextWithMetadata[]> => {
+  if (!course_name || !search_query) {
+    return res.status(400).json({ 
+      error: 'course_name and search_query are required' 
+    })
+  }
+
   const requestBody = {
     course_name: course_name,
     search_query: search_query,
@@ -15,37 +20,8 @@ export const fetchContexts = async (
     doc_groups: doc_groups,
   }
 
-  // UESFUL FOR TESTING -- SHORTEN CONTEXTS
-  // const dummyContexts: ContextWithMetadata[] = [
-  //   {
-  //     id: 1,
-  //     text: 'This is a dummy context',
-  //     readable_filename: 'dummy_filename_1.pdf',
-  //     course_name: 'dummy course 1',
-  //     'course_name ': 'dummy course 1',
-  //     s3_path: 'dummy_s3_path_1',
-  //     pagenumber: '1',
-  //     url: 'dummy_url_1',
-  //     base_url: 'dummy_base_url_1',
-  //   },
-  //   {
-  //     id: 2,
-  //     text: 'This is another dummy context',
-  //     readable_filename: 'dummy_filename_2.pdf',
-  //     course_name: 'dummy course 2',
-  //     'course_name ': 'dummy course 2',
-  //     s3_path: 'dummy_s3_path_2',
-  //     pagenumber: '2',
-  //     url: 'dummy_url_2',
-  //     base_url: 'dummy_base_url_2',
-  //   },
-  // ]
-  // return dummyContexts
-
-  const url = `https://flask-production-751b.up.railway.app/getTopContexts`
-
   try {
-    const response = await fetch(url, {
+    const response = await fetch(`${process.env.RAILWAY_URL}/getTopContexts`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -55,8 +31,48 @@ export const fetchContexts = async (
 
     if (!response.ok) {
       console.error('Failed to fetch contexts. Err status:', response.status)
-      throw new Error('Failed to fetch contexts. Err status:' + response.status)
+      return res.status(response.status).json({ 
+        error: `Failed to fetch contexts. Status: ${response.status}` 
+      })
     }
+    
+    const data: ContextWithMetadata[] = await response.json()
+    return res.status(200).json(data)
+  } catch (error) {
+    console.error('Error fetching contexts:', error)
+    return res.status(500).json({ 
+      error: 'Internal server error while fetching contexts',
+      data: []
+    })
+  }
+}
+
+// Helper function for backward compatibility
+export const fetchContexts = async (
+  course_name: string,
+  search_query: string,
+  token_limit = 4000,
+  doc_groups: string[] = [],
+): Promise<ContextWithMetadata[]> => {
+  try {
+    const response = await fetch('/api/getContexts', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        course_name,
+        search_query,
+        token_limit,
+        doc_groups,
+      }),
+    })
+
+    if (!response.ok) {
+      console.error('Failed to fetch contexts. Err status:', response.status)
+      return []
+    }
+    
     const data: ContextWithMetadata[] = await response.json()
     return data
   } catch (error) {
@@ -64,4 +80,3 @@ export const fetchContexts = async (
     return []
   }
 }
-export default fetchContexts

--- a/src/pages/api/getContextsMQR.ts
+++ b/src/pages/api/getContextsMQR.ts
@@ -16,8 +16,10 @@ export default async function handler(req: any, res: any) {
 
   try {
     // Note: This uses a different Railway service endpoint than the main RAILWAY_URL
-    // You may need to set RAILWAY_MQR_URL or similar environment variable
-    const mqrUrl = process.env.RAILWAY_MQR_URL || 'https://flask-doc-groups.up.railway.app'
+    const mqrUrl = process.env.RAILWAY_MQR_URL
+    if (!mqrUrl) {
+      throw new Error('No MQR backend URL configured. Please set RAILWAY_MQR_URL environment variable.')
+    }
     const response: AxiosResponse<ContextWithMetadata[]> = await axios.get(
       `${mqrUrl}/getTopContextsWithMQR`,
       {

--- a/src/pages/api/getContextsMQR.ts
+++ b/src/pages/api/getContextsMQR.ts
@@ -1,29 +1,72 @@
 import axios, { AxiosResponse } from 'axios'
 import { ContextWithMetadata } from '~/types/chat'
 
-export const fetchMQRContexts = async (
-  course_name: string,
-  search_query: string,
-  token_limit = 6000,
-  doc_groups: string[] = [],
-) => {
+export default async function handler(req: any, res: any) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  const { course_name, search_query, token_limit = 6000, doc_groups = [] } = req.query
+
+  if (!course_name || !search_query) {
+    return res.status(400).json({ 
+      error: 'course_name and search_query are required' 
+    })
+  }
+
   try {
+    // Note: This uses a different Railway service endpoint than the main RAILWAY_URL
+    // You may need to set RAILWAY_MQR_URL or similar environment variable
+    const mqrUrl = process.env.RAILWAY_MQR_URL || 'https://flask-doc-groups.up.railway.app'
     const response: AxiosResponse<ContextWithMetadata[]> = await axios.get(
-      `https://flask-doc-groups.up.railway.app/getTopContextsWithMQR`,
+      `${mqrUrl}/getTopContextsWithMQR`,
       {
         params: {
           course_name: course_name,
           search_query: search_query,
           token_limit: token_limit,
-          doc_groups: doc_groups,
+          doc_groups: Array.isArray(doc_groups) ? doc_groups : [doc_groups].filter(Boolean),
         },
       },
     )
-    return response.data
+    return res.status(200).json(response.data)
+  } catch (error) {
+    console.error('Error fetching MQR contexts:', error)
+    return res.status(500).json({ 
+      error: 'Internal server error while fetching MQR contexts',
+      data: []
+    })
+  }
+}
+
+// Helper function for backward compatibility
+export const fetchMQRContexts = async (
+  course_name: string,
+  search_query: string,
+  token_limit = 6000,
+  doc_groups: string[] = [],
+): Promise<ContextWithMetadata[]> => {
+  try {
+    const params = new URLSearchParams({
+      course_name,
+      search_query,
+      token_limit: token_limit.toString(),
+    })
+    
+    // Handle doc_groups array
+    doc_groups.forEach(group => params.append('doc_groups', group))
+    
+    const response = await fetch(`/api/getContextsMQR?${params.toString()}`)
+
+    if (!response.ok) {
+      console.error('Failed to fetch MQR contexts. Err status:', response.status)
+      return []
+    }
+    
+    const data: ContextWithMetadata[] = await response.json()
+    return data
   } catch (error) {
     console.error(error)
     return []
   }
 }
-
-export default fetchMQRContexts

--- a/src/pages/api/getNomicMapForQueries.ts
+++ b/src/pages/api/getNomicMapForQueries.ts
@@ -1,10 +1,17 @@
+import { getBackendUrl } from '~/utils/apiUtils'
+
+interface NomicMapData {
+  map_id: string
+  map_link: string
+}
+
 export default async function handler(req: any, res: any) {
   try {
     const { course_name, map_type } = req.query
 
     // Example response:  {'map_id': 'iframef4967ad7-ff37-4098-ad06-7e1e1a93dd93', 'map_link': 'https://atlas.nomic.ai/map/ed222613-97d9-46a9-8755-12bbc8a06e3a/f4967ad7-ff37-4098-ad06-7e1e1a93dd93'}
     const response = await fetch(
-      `${process.env.RAILWAY_URL}/getNomicMap?course_name=${course_name}&map_type=${map_type}`,
+      `${getBackendUrl()}/getNomicMap?course_name=${course_name}&map_type=${map_type}`,
     )
     const data = await response.json()
 

--- a/src/pages/api/getNomicMapForQueries.ts
+++ b/src/pages/api/getNomicMapForQueries.ts
@@ -1,15 +1,10 @@
-import { type NextRequest, NextResponse } from 'next/server'
-
-export const runtime = 'edge'
-
-export default async function handler(req: NextRequest, res: NextResponse) {
+export default async function handler(req: any, res: any) {
   try {
-    const course_name = req.nextUrl.searchParams.get('course_name')
-    const map_type = req.nextUrl.searchParams.get('map_type')
+    const { course_name, map_type } = req.query
 
     // Example response:  {'map_id': 'iframef4967ad7-ff37-4098-ad06-7e1e1a93dd93', 'map_link': 'https://atlas.nomic.ai/map/ed222613-97d9-46a9-8755-12bbc8a06e3a/f4967ad7-ff37-4098-ad06-7e1e1a93dd93'}
     const response = await fetch(
-      `https://flask-production-751b.up.railway.app/getNomicMap?course_name=${course_name}&map_type=${map_type}`,
+      `${process.env.RAILWAY_URL}/getNomicMap?course_name=${course_name}&map_type=${map_type}`,
     )
     const data = await response.json()
 
@@ -17,9 +12,9 @@ export default async function handler(req: NextRequest, res: NextResponse) {
       map_id: data.map_id,
       map_link: data.map_link,
     }
-    return NextResponse.json(parsedData)
+    return res.status(200).json(parsedData)
   } catch (error) {
     console.error('getNomicMapForQueries - Error fetching nomic map:', error)
-    return NextResponse.json({ success: false })
+    return res.status(500).json({ success: false })
   }
 }

--- a/src/utils/apiUtils.ts
+++ b/src/utils/apiUtils.ts
@@ -1,11 +1,11 @@
 // utils/apiUtils.ts
-import {
-  type CourseMetadataOptionalForUpsert,
-  type CourseMetadata,
-} from '~/types/courseMetadata'
+import { CoreMessage } from 'ai'
 import { v4 as uuidv4 } from 'uuid'
 import { Conversation, Message } from '~/types/chat'
-import { CoreMessage } from 'ai'
+import {
+  type CourseMetadata,
+  type CourseMetadataOptionalForUpsert,
+} from '~/types/courseMetadata'
 
 // Configuration for runtime environment
 
@@ -14,6 +14,25 @@ export const getBaseUrl = () => {
   if (process.env.VERCEL_ENV == 'production') return 'https://uiuc.chat'
   if (process.env.VERCEL_URL) return `https://${process.env.VERCEL_URL}` // SSR should use vercel url
   return `http://localhost:${process.env.PORT ?? 3000}` // dev SSR should use localhost
+}
+
+/**
+ * Gets the backend URL from environment variables.
+ * Throws an error if RAILWAY_URL is not configured.
+ * @returns {string} - The validated backend URL
+ * @throws {Error} - If RAILWAY_URL is not set
+ */
+export const getBackendUrl = (): string => {
+  const backendUrl = process.env.RAILWAY_URL
+  
+  if (!backendUrl) {
+    throw new Error(
+      'Backend URL is not configured. Please set the RAILWAY_URL environment variable.'
+    )
+  }
+  
+  // Remove trailing slash if present for consistency
+  return backendUrl.endsWith('/') ? backendUrl.slice(0, -1) : backendUrl
 }
 
 /**

--- a/src/utils/functionCalling/handleFunctionCalling.ts
+++ b/src/utils/functionCalling/handleFunctionCalling.ts
@@ -259,7 +259,7 @@ const callN8nFunction = async (
   })
 
   const timeStart = Date.now()
-  const baseUrl = base_url || 'https://flask-production-751b.up.railway.app'
+  const baseUrl = base_url || process.env.RAILWAY_URL || 'https://flask-production-751b.up.railway.app'
   const response: Response = await fetch(
     `${baseUrl}/run_flow`,
     {
@@ -530,7 +530,7 @@ export async function fetchTools(
 
   const parsedPagination = pagination.toLowerCase() === 'true'
 
-  const baseUrl = base_url || 'https://flask-production-751b.up.railway.app'
+  const baseUrl = base_url || process.env.RAILWAY_URL || 'https://flask-production-751b.up.railway.app'
   const response = await fetch(
     `${baseUrl}/getworkflows?api_key=${api_key}&limit=${limit}&pagination=${parsedPagination}`,
   )

--- a/src/utils/functionCalling/handleFunctionCalling.ts
+++ b/src/utils/functionCalling/handleFunctionCalling.ts
@@ -259,7 +259,10 @@ const callN8nFunction = async (
   })
 
   const timeStart = Date.now()
-  const baseUrl = base_url || process.env.RAILWAY_URL || 'https://flask-production-751b.up.railway.app'
+  const baseUrl = base_url || process.env.RAILWAY_URL
+  if (!baseUrl) {
+    throw new Error('No backend URL configured. Please provide base_url parameter or set RAILWAY_URL environment variable.')
+  }
   const response: Response = await fetch(
     `${baseUrl}/run_flow`,
     {
@@ -530,7 +533,10 @@ export async function fetchTools(
 
   const parsedPagination = pagination.toLowerCase() === 'true'
 
-  const baseUrl = base_url || process.env.RAILWAY_URL || 'https://flask-production-751b.up.railway.app'
+  const baseUrl = base_url || process.env.RAILWAY_URL
+  if (!baseUrl) {
+    throw new Error('No backend URL configured. Please provide base_url parameter or set RAILWAY_URL environment variable.')
+  }
   const response = await fetch(
     `${baseUrl}/getworkflows?api_key=${api_key}&limit=${limit}&pagination=${parsedPagination}`,
   )

--- a/src/utils/functionCalling/handleFunctionCalling.ts
+++ b/src/utils/functionCalling/handleFunctionCalling.ts
@@ -259,8 +259,9 @@ const callN8nFunction = async (
   })
 
   const timeStart = Date.now()
+  const baseUrl = base_url || 'https://flask-production-751b.up.railway.app'
   const response: Response = await fetch(
-    `https://flask-production-751b.up.railway.app/run_flow`,
+    `${baseUrl}/run_flow`,
     {
       method: 'POST',
       headers: {
@@ -529,8 +530,9 @@ export async function fetchTools(
 
   const parsedPagination = pagination.toLowerCase() === 'true'
 
+  const baseUrl = base_url || 'https://flask-production-751b.up.railway.app'
   const response = await fetch(
-    `https://flask-production-751b.up.railway.app/getworkflows?api_key=${api_key}&limit=${limit}&pagination=${parsedPagination}`,
+    `${baseUrl}/getworkflows?api_key=${api_key}&limit=${limit}&pagination=${parsedPagination}`,
   )
   if (!response.ok) {
     // return res.status(response.status).json({ error: response.statusText })

--- a/src/utils/functionCalling/handleFunctionCalling.ts
+++ b/src/utils/functionCalling/handleFunctionCalling.ts
@@ -9,6 +9,7 @@ import {
   type N8nWorkflow,
   type OpenAICompatibleTool,
 } from '~/types/tools'
+import { getBackendUrl } from '~/utils/apiUtils'
 
 export async function handleFunctionCall(
   message: Message,
@@ -566,7 +567,7 @@ export async function fetchTools(
     )
   } else {
     // Server-side: use direct backend call
-    const backendUrl = process.env.RAILWAY_URL
+    const backendUrl = getBackendUrl()
     if (!backendUrl) {
       throw new Error('No backend URL configured. Please provide base_url parameter or set RAILWAY_URL environment variable.')
     }

--- a/src/utils/streamProcessing.ts
+++ b/src/utils/streamProcessing.ts
@@ -25,8 +25,8 @@ import {
   type SambaNovaProvider,
   ProviderNames,
 } from '~/utils/modelProviders/LLMProvider'
-import fetchMQRContexts from '~/pages/api/getContextsMQR'
-import fetchContexts from '~/pages/api/getContexts'
+import { fetchMQRContexts } from '~/pages/api/getContextsMQR'
+import { fetchContexts } from '~/pages/api/getContexts'
 import { OllamaModelIDs } from './modelProviders/ollama'
 import { webLLMModels } from './modelProviders/WebLLM'
 import { OpenAIModelID } from './modelProviders/types/openai'

--- a/src/utils/streamProcessing.ts
+++ b/src/utils/streamProcessing.ts
@@ -1,3 +1,16 @@
+import { type CoreMessage } from 'ai'
+import { type NextApiRequest, type NextApiResponse } from 'next'
+import posthog from 'posthog-js'
+import { v4 as uuidv4 } from 'uuid'
+import { runBedrockChat } from '~/app/api/chat/bedrock/route'
+import { runGeminiChat } from '~/app/api/chat/gemini/route'
+import { runSambaNovaChat } from '~/app/api/chat/sambanova/route'
+import { runAnthropicChat } from '~/app/utils/anthropic'
+import { runOllamaChat } from '~/app/utils/ollama'
+import { runVLLM } from '~/app/utils/vllm'
+import { fetchContexts } from '~/pages/api/getContexts'
+import fetchMQRContexts from '~/pages/api/getContextsMQR'
+import { fetchImageDescription } from '~/pages/api/UIUC-api/fetchImageDescription'
 import {
   type ChatApiBody,
   type ChatBody,
@@ -7,45 +20,32 @@ import {
   type Message,
 } from '~/types/chat'
 import { type CourseMetadata } from '~/types/courseMetadata'
-import { OpenAIError } from './server'
-import { replaceCitationLinks } from './citations'
-import { fetchImageDescription } from '~/pages/api/UIUC-api/fetchImageDescription'
 import { getBaseUrl } from '~/utils/apiUtils'
-import posthog from 'posthog-js'
 import {
   type AllLLMProviders,
   AllSupportedModels,
   type AnthropicProvider,
+  type BedrockProvider,
+  type GeminiProvider,
   type GenericSupportedModel,
   type NCSAHostedVLMProvider,
   type OllamaProvider,
-  VisionCapableModels,
-  type BedrockProvider,
-  type GeminiProvider,
-  type SambaNovaProvider,
   ProviderNames,
+  type SambaNovaProvider,
+  VisionCapableModels,
 } from '~/utils/modelProviders/LLMProvider'
-import { fetchMQRContexts } from '~/pages/api/getContextsMQR'
-import { fetchContexts } from '~/pages/api/getContexts'
-import { OllamaModelIDs } from './modelProviders/ollama'
-import { webLLMModels } from './modelProviders/WebLLM'
-import { OpenAIModelID } from './modelProviders/types/openai'
-import { v4 as uuidv4 } from 'uuid'
+import { replaceCitationLinks } from './citations'
 import { AzureModelID } from './modelProviders/azure'
+import { OllamaModelIDs } from './modelProviders/ollama'
+import { openAIAzureChat } from './modelProviders/OpenAIAzureChat'
 import { AnthropicModelID } from './modelProviders/types/anthropic'
-import { type NextApiRequest, type NextApiResponse } from 'next'
 import { BedrockModelID } from './modelProviders/types/bedrock'
 import { GeminiModelID } from './modelProviders/types/gemini'
-import { SambaNovaModelID } from './modelProviders/types/SambaNova'
-import { runOllamaChat } from '~/app/utils/ollama'
-import { openAIAzureChat } from './modelProviders/OpenAIAzureChat'
-import { runAnthropicChat } from '~/app/utils/anthropic'
 import { NCSAHostedVLMModelID } from './modelProviders/types/NCSAHostedVLM'
-import { runVLLM } from '~/app/utils/vllm'
-import { type CoreMessage } from 'ai'
-import { runGeminiChat } from '~/app/api/chat/gemini/route'
-import { runBedrockChat } from '~/app/api/chat/bedrock/route'
-import { runSambaNovaChat } from '~/app/api/chat/sambanova/route'
+import { OpenAIModelID } from './modelProviders/types/openai'
+import { SambaNovaModelID } from './modelProviders/types/SambaNova'
+import { webLLMModels } from './modelProviders/WebLLM'
+import { OpenAIError } from './server'
 
 /**
  * Enum representing the possible states of the state machine used in processing text chunks.


### PR DESCRIPTION
Hardcoded backend URLs were addressed by abstracting them behind Next.js API routes and utilizing environment variables.

*   **Client-Side Fixes**:
    *   `src/pages/[course_name]/tools.tsx` now calls `/api/UIUC-api/getAllCourseData`.
    *   `src/components/UIUC-Components/WebScrape.tsx` and `src/components/UIUC-Components/MITIngestForm.tsx` now call `/api/UIUC-api/downloadMITCourse`.
    *   `src/components/UIUC-Components/ProjectFilesTable.tsx` and `src/components/UIUC-Components/MakeQueryAnalysisPage.tsx` now call `/api/UIUC-api/deleteDocument`.
    *   This eliminates direct client-side exposure of the backend URL.

*   **New API Wrapper Routes**:
    *   `src/pages/api/UIUC-api/getAllCourseData.ts`
    *   `src/pages/api/UIUC-api/downloadMITCourse.ts`
    *   `src/pages/api/UIUC-api/deleteDocument.ts`
    *   These new routes act as intermediaries, forwarding requests to the actual backend using `process.env.RAILWAY_URL`.

*   **Server-Side Updates**:
    *   `src/pages/api/UIUC-api/ingestCanvas.ts`, `downloadConvoHistoryUser.ts`, `downloadConvoHistory.ts`, and `exportAllDocuments.ts` were updated to use `process.env.RAILWAY_URL`.
    *   `src/utils/functionCalling/handleFunctionCalling.ts` was updated to accept a `base_url` parameter, defaulting to the hardcoded URL if not provided, for `run_flow` and `getworkflows` calls.

This change significantly improves security by preventing client-side code from directly exposing backend endpoint URLs.