### PR TITLE
Investigate handleSaveApiKey api failure

### DIFF
--- a/src/pages/api/UIUC-api/tools/upsertN8nAPIKey.ts
+++ b/src/pages/api/UIUC-api/tools/upsertN8nAPIKey.ts
@@ -1,21 +1,24 @@
 import { supabase } from '@/utils/supabaseClient'
-import { NextRequest, NextResponse } from 'next/server'
+import { NextApiRequest, NextApiResponse } from 'next'
 
-
-
-export default async function handler(req: NextRequest, res: NextResponse) {
-  const requestBody = await req.json()
-  // console.log('upsertN8nAPIKey course_name and n8n_api_key:', requestBody)
-  const { course_name, n8n_api_key } = requestBody
-  if (!course_name) {
-    return new NextResponse(
-      JSON.stringify({
-        success: false,
-        error: 'course_name is required',
-      }),
-      { status: 400 },
-    )
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ success: false, error: 'Method not allowed' })
   }
+
+  const { course_name, n8n_api_key } = req.body
+  // console.log('upsertN8nAPIKey course_name and n8n_api_key:', req.body)
+  
+  if (!course_name) {
+    return res.status(400).json({
+      success: false,
+      error: 'course_name is required',
+    })
+  }
+
   const { data, error } = await supabase
     .from('projects')
     .upsert(
@@ -33,9 +36,8 @@ export default async function handler(req: NextRequest, res: NextResponse) {
 
   if (error) {
     console.error('Error upserting N8n key to Supabase:', error)
-    return new NextResponse(JSON.stringify({ success: false, error: error }), {
-      status: 500,
-    })
+    return res.status(500).json({ success: false, error: error })
   }
-  return new NextResponse(JSON.stringify({ success: true }), { status: 200 })
+  
+  return res.status(200).json({ success: true })
 }


### PR DESCRIPTION
Refactor `upsertN8nAPIKey` API endpoint to use Pages Router format, fixing '405 Method Not Allowed' error.

The `upsertN8nAPIKey.ts` endpoint was incorrectly using App Router types (`NextRequest`, `NextResponse`) instead of the Pages Router types (`NextApiRequest`, `NextApiResponse`) expected by the project's API structure. This mismatch caused POST requests to fail with a 405 Method Not Allowed error, preventing the n8n API key from being saved. This change aligns the endpoint with the rest of the codebase.

---

[Slack Thread](https://aifarms.slack.com/archives/C05QL4EM9D3/p1753141669552069?thread_ts=1753141669.552069&cid=C05QL4EM9D3) • [Open in Web](https://www.cursor.com/agents?id=bc-0fb17225-304b-4d5f-8c67-8fa8d672f53d) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-0fb17225-304b-4d5f-8c67-8fa8d672f53d)