### PR TITLE
Doc groups cleanup

### DIFF
--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -12,7 +12,8 @@ import {
   bigint,
   date,
   doublePrecision,
-  bigserial
+  bigserial,
+  uniqueIndex,
 } from 'drizzle-orm/pg-core'
 import { relations } from 'drizzle-orm'
 
@@ -206,23 +207,44 @@ export const courseNames = pgTable('course_names', {
 })
 
 // DocGroups table
-export const docGroups = pgTable('doc_groups', {
-  id: serial('id').primaryKey(),
-  name: text('name').notNull(),
-  course_name: text('course_name').notNull(),
-  created_at: timestamp('created_at').defaultNow(),
-  enabled: boolean('enabled').default(true),
-  private: boolean('private').default(true),
-  doc_count: integer('doc_count').default(0),
-})
+export const docGroups = pgTable(
+  'doc_groups',
+  {
+    id: serial('id').primaryKey(),
+    name: text('name').notNull(),
+    course_name: text('course_name').notNull(),
+    created_at: timestamp('created_at').defaultNow(),
+    enabled: boolean('enabled').default(true),
+    private: boolean('private').default(true),
+    doc_count: integer('doc_count').default(0),
+  },
+  (table) => {
+    return {
+      nameCourseUnique: uniqueIndex('doc_groups_name_course_unique').on(
+        table.name,
+        table.course_name,
+      ),
+    }
+  },
+)
 
 // Define the junction table for documents and doc_groups many-to-many relationship
-export const documentsDocGroups = pgTable('documents_doc_groups', {
-  id: serial('id').primaryKey(),
-  document_id: integer('document_id').notNull(),
-  doc_group_id: integer('doc_group_id').notNull(),
-  created_at: timestamp('created_at').defaultNow(),
-})
+export const documentsDocGroups = pgTable(
+  'documents_doc_groups',
+  {
+    id: serial('id').primaryKey(),
+    document_id: integer('document_id').notNull(),
+    doc_group_id: integer('doc_group_id').notNull(),
+    created_at: timestamp('created_at').defaultNow(),
+  },
+  (table) => {
+    return {
+      docIDsUnique: uniqueIndex(
+        'documents_doc_groups_document_group_id_unique',
+      ).on(table.document_id, table.doc_group_id),
+    }
+  },
+)
 
 // Doc Groups Sharing table (from schema.sql)
 export const docGroupsSharing = pgTable('doc_groups_sharing', {
@@ -368,7 +390,7 @@ export const projectStats = pgTable('project_stats', {
   unique_users: integer('unique_users').default(0),
   created_at: timestamp('created_at').defaultNow().notNull(),
   updated_at: timestamp('updated_at').defaultNow().notNull(),
-  model_usage_counts: jsonb('model_usage_counts')
+  model_usage_counts: jsonb('model_usage_counts'),
 })
 
 // PubMed Daily Update (from schema.sql)


### PR DESCRIPTION
Fix formatting of array that was being passed into query.

Add uniqueness constraint to table so insert query succeeds.

Key queries for Postgres (pending migration):
```
CREATE UNIQUE INDEX "doc_groups_name_course_unique" ON "doc_groups" USING btree ("name","course_name");  

CREATE UNIQUE INDEX "documents_doc_groups_document_group_id_unique" ON "documents_doc_groups" USING btree ("document_id","doc_group_id");
```