### PR TITLE
fix the permission check logic

### DIFF
--- a/src/components/UIUC-Components/runAuthCheck.tsx
+++ b/src/components/UIUC-Components/runAuthCheck.tsx
@@ -18,19 +18,6 @@ export const get_user_permission = (
       return 'no_permission'
     }
 
-    // if private && not signed in, redirect
-    if (course_metadata.is_private && !auth.isAuthenticated) {
-      console.log('private && not signed in. Auth: no_permission.')
-      return 'no_permission'
-    }
-
-    if (course_metadata.is_private && auth.isAuthenticated){
-      if (course_metadata.allow_logged_in_users) {
-        console.log('private && allow_logged_in_users. Auth: view.')
-        return 'view'
-      }
-    }
-
     // Get user email from OIDC profile
     const userEmail = auth.user?.profile.email
 
@@ -53,8 +40,6 @@ export const get_user_permission = (
         return 'view'
       }
     } else {
-      // Course is Private
-
       if (!auth.isAuthenticated) {
         console.log(
           'User is not signed in. Course is private. Auth: no_permission.',
@@ -76,7 +61,14 @@ export const get_user_permission = (
       ) {
         // Not owner or admin, can't edit. But is USER so CAN VIEW
         return 'view'
-      } else {
+      }
+      else if (course_metadata.allow_logged_in_users) {
+        // special case for private courses with allow_logged_in_users
+        console.log('private && allow_logged_in_users. Auth: view.')
+        return 'view'
+      }
+      else
+      {
         // Cannot edit or view
         console.log(
           'User is not an admin, owner, or approved user. Course is private. Auth: no_permission.',


### PR DESCRIPTION
I ask chatGPT to summarize the current logic flow for ease of understanding:

### Logic for get_user_permission
1. Check course metadata exists: If course_metadata is missing or empty → throw error.
2. Check auth state first
 - If auth.isLoading → return no_permission.
 - If auth.error → log error & return no_permission.
3. Extract userEmail from OIDC profile.

Then 
### Case A: Course is Public (!course_metadata.is_private)
If not authenticated → return view (public can view).
If authenticated:
- If userEmail is course_owner or in course_admins → return edit.
- Else → return view (public but not admin).

Then

### Case B: Course is Private (course_metadata.is_private)
If not authenticated → return no_permission.
If authenticated:
- If userEmail is course_owner or in course_admins → return edit.
- Else if userEmail is in approved_emails_list → return view.
- Else if allow_logged_in_users = true → return view.
- Else → return no_permission.