### PR TITLE
About us tweaks for Illinois.chat instance

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -127,7 +127,6 @@ const TypingAnimation: React.FC = () => {
 }
 
 const Home: NextPage = () => {
-  const [isTooltipVisible, setIsTooltipVisible] = useState(false)
   const useIllinoisChatConfig = useMemo(() => {
     return process.env.NEXT_PUBLIC_USE_ILLINOIS_CHAT_CONFIG === 'True'
   }, [])
@@ -176,50 +175,21 @@ const Home: NextPage = () => {
           className={`inline-block ${montserrat_heading.variable} font-montserratHeading`}
         >
           <div className="relative inline-block cursor-help">
-                <span
-                  className="text-lg font-bold"
-                  onMouseEnter={() => setIsTooltipVisible(true)}
-                  onMouseLeave={() => setIsTooltipVisible(false)}
-                >
-                  {/*1. If useIllinoisChatConfig && IllinoisChatBannerContent → render HTML from IllinoisChatBannerContent*/}
-                  {/*2. If !useIllinoisChatConfig → render default "Heads up" banner*/}
-                  {/*3. Otherwise → render nothing*/}
-                  {
-                    useIllinoisChatConfig && IllinoisChatBannerContent ? (
-                      <div dangerouslySetInnerHTML={{ __html: IllinoisChatBannerContent }} />
-                    ) : !useIllinoisChatConfig ? (
-                      <>
-                        Heads up: we’ve rebranded to Illinois Chat — please visit{' '}
-                        <a
-                          href="https://chat.illinois.edu"
-                          className="underline"
-                        >
-                          chat.illinois.edu
-                        </a>
-                      </>
-                    ) : null
-                  }
-              </span>
-
-            <div
-              className={`absolute left-1/2 top-full z-50 mt-2 w-72 -translate-x-1/2 transform rounded p-2 text-sm transition duration-300 ${isTooltipVisible ? 'opacity-100' : 'pointer-events-none opacity-0'}`}
-              style={{
-                background: '#333',
-                border: '1px solid #444',
-                boxShadow: '0 2px 5px rgba(0,0,0,0.2)',
-              }}
-            >
-              We&apos;re on our way to becoming a production service for all U
-              of I campuses.
+            {/*1. If useIllinoisChatConfig && IllinoisChatBannerContent → render HTML from IllinoisChatBannerContent*/}
+            {/*2. If !useIllinoisChatConfig → render default "Heads up" banner*/}
+            {/*3. Otherwise → render nothing*/}
+            {useIllinoisChatConfig && IllinoisChatBannerContent ? (
               <div
-                className="absolute bottom-full left-1/2 h-0 w-0 -translate-x-1/2 transform"
-                style={{
-                  borderLeft: '8px solid transparent',
-                  borderRight: '8px solid transparent',
-                  borderBottom: '8px solid #333',
-                }}
-              ></div>
-            </div>
+                dangerouslySetInnerHTML={{ __html: IllinoisChatBannerContent }}
+              />
+            ) : !useIllinoisChatConfig ? (
+              <>
+                Heads up: we’ve rebranded to Illinois Chat — please visit{' '}
+                <a href="https://chat.illinois.edu" className="underline">
+                  chat.illinois.edu
+                </a>
+              </>
+            ) : null}
           </div>
         </div>
       </div>
@@ -230,8 +200,7 @@ const Home: NextPage = () => {
         className={`illinois-blue-gradient-bg flex min-h-screen flex-col items-center justify-center overflow-hidden
           ${montserrat_paragraph.variable} font-montserratParagraph`}
       >
-        <div
-          className="container flex w-full max-w-5xl flex-col items-center justify-center gap-4 px-4 py-8 sm:px-8 sm:py-20">
+        <div className="container flex w-full max-w-5xl flex-col items-center justify-center gap-4 px-4 py-8 sm:px-8 sm:py-20">
           <div
             className="
             flex w-full
@@ -312,9 +281,7 @@ const Home: NextPage = () => {
             </div>
           </div>
 
-          {
-            !useIllinoisChatConfig &&
-
+          {!useIllinoisChatConfig && (
             <div className="mt-12 w-[100vw] rounded-lg bg-[--dashboard-background-faded] p-8 pb-14">
               <div className="mb-6 w-full pt-8 text-center">
                 <h2
@@ -341,8 +308,7 @@ const Home: NextPage = () => {
                 <FlagshipChatbots />
               </div>
             </div>
-
-          }
+          )}
         </div>
 
         {/* orange banner */}
@@ -383,8 +349,7 @@ const Home: NextPage = () => {
         </div>
 
         {/* second section below the orange banner */}
-        <div
-          className="container flex w-full max-w-5xl flex-col items-center justify-center gap-4 overflow-hidden px-4 py-8 sm:px-8 sm:py-20">
+        <div className="container flex w-full max-w-5xl flex-col items-center justify-center gap-4 overflow-hidden px-4 py-8 sm:px-8 sm:py-20">
           <h2
             className={`
               max-w-lg
@@ -721,7 +686,7 @@ const Home: NextPage = () => {
 
             <div
               className="
-              mt-0 
+              mt-0
               sm:mt-0 sm:w-2/3
             "
             >
@@ -825,8 +790,7 @@ const Home: NextPage = () => {
         </div>
 
         {/* second section below the blue banner */}
-        <div
-          className="container flex w-full max-w-5xl flex-col items-center justify-center gap-4 overflow-hidden px-4 py-8 sm:px-8 sm:py-20">
+        <div className="container flex w-full max-w-5xl flex-col items-center justify-center gap-4 overflow-hidden px-4 py-8 sm:px-8 sm:py-20">
           <h4
             className={`
             text-4xl font-extrabold tracking-tight
@@ -960,7 +924,7 @@ function FlagshipChatbots() {
       badge: 'Illinois',
       tagline: 'Find professors based on your research interests',
       description:
-        'Using all of Illinois\'s documentation, get detailed examples, advice and information about the conference.',
+        "Using all of Illinois's documentation, get detailed examples, advice and information about the conference.",
     },
     {
       course_slug: 'NeurIPS-2024',
@@ -970,7 +934,7 @@ function FlagshipChatbots() {
       tagline:
         'Trained on all 4,000+ papers from the largest AI conference in the world',
       description:
-        'Using all of NeurIPS 2024\'s documentation, get detailed examples, advice and information about the conference.',
+        "Using all of NeurIPS 2024's documentation, get detailed examples, advice and information about the conference.",
     },
     {
       course_slug: 'NCSADelta',
@@ -978,9 +942,9 @@ function FlagshipChatbots() {
       title: 'NCSA Delta Supercomputer',
       badge: 'NCSA Docs',
       tagline:
-        'Quickstart on our Delta supercomputer, it\'ll write SLRUM scripts for you 😁',
+        "Quickstart on our Delta supercomputer, it'll write SLRUM scripts for you 😁",
       description:
-        'Using all of Delta\'s documentation, get detailed examples, advice and information about how to use the Delta supercomputer.',
+        "Using all of Delta's documentation, get detailed examples, advice and information about how to use the Delta supercomputer.",
     },
     /*
     {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -789,8 +789,9 @@ const Home: NextPage = () => {
                   style={{ color: 'var(--illinois-orange)' }}
                   href="mailto:caii_ai@lists.illinois.edu"
                 >
-                  caii_ai@lists.illinois.edu
+                  contact us
                 </a>
+                .
               </div>
             </div>
           </div>
@@ -817,13 +818,12 @@ const Home: NextPage = () => {
                 Support
               </h3>
               <div className="text-md">
-                If you have any questions or would like to submit a bug please
-                email us at{' '}
+                If you have any questions or would like to submit a bug please{' '}
                 <a
                   style={{ color: 'var(--illinois-orange)' }}
                   href="mailto:genaisupport@mx.uillinois.edu"
                 >
-                  genaisupport@mx.uillinois.edu
+                  email us
                 </a>
                 .
               </div>
@@ -838,12 +838,16 @@ const Home: NextPage = () => {
               >
                 Open source
               </h3>
-              <a
-                style={{ color: 'var(--illinois-orange)' }}
-                href="mailto:genaisupport@mx.uillinois.edu"
-              >
-                MIT License
-              </a>
+              <div className="text-md">
+                All code is open source. Join us on{' '}
+                <a
+                  style={{ color: 'var(--illinois-orange)' }}
+                  href="https://github.com/Center-for-AI-Innovation"
+                >
+                  GitHub
+                </a>
+                .
+              </div>
             </div>
             <div className="flex max-w-xs flex-col gap-4 rounded-xl bg-[--dashboard-background-faded] p-6">
               <h3
@@ -862,7 +866,7 @@ const Home: NextPage = () => {
                 >
                   Center of AI Innovation
                 </a>{' '}
-                at the{' '}
+                at{' '}
                 <a
                   style={{ color: 'var(--illinois-orange)' }}
                   href="https://ncsa.illinois.edu/"

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -761,6 +761,39 @@ const Home: NextPage = () => {
               </div>
             </div>
           </div>
+
+          <div
+            className="
+              mx-auto flex
+              w-full
+
+              max-w-3xl flex-col items-start justify-center
+              gap-16 sm:flex-row
+            "
+          >
+            <div className="mt-16">
+              <h2
+                className={`
+                text-xl font-bold
+                ${montserrat_heading.variable} font-montserratHeading
+              `}
+              >
+                Want something custom?
+              </h2>
+
+              <div className="mt-4">
+                We collaborate with researchers and industry partners to develop
+                custom features on this platform. For inquiries, please contact
+                us at{' '}
+                <a
+                  style={{ color: 'var(--illinois-orange)' }}
+                  href="mailto:caii_ai@lists.illinois.edu"
+                >
+                  caii_ai@lists.illinois.edu
+                </a>
+              </div>
+            </div>
+          </div>
         </div>
 
         {/* second section below the blue banner */}
@@ -774,11 +807,7 @@ const Home: NextPage = () => {
             About Us
           </h4>
           <div className="mt-4 grid grid-cols-1 gap-14 sm:grid-cols-3 md:gap-8">
-            <Link
-              className="duration-600 flex max-w-xs flex-col gap-4 rounded-xl bg-[--dashboard-background-faded] p-6 transition-transform hover:scale-[1.01]"
-              href="mailto:genaisupport@mx.uillinois.edu"
-              target="_blank"
-            >
+            <div className="flex max-w-xs flex-col gap-4 rounded-xl bg-[--dashboard-background-faded] p-6">
               <h3
                 className={`
                 text-xl font-bold
@@ -799,12 +828,8 @@ const Home: NextPage = () => {
                 .
               </div>
               {/* <div className="text-lg">Sponsored by the </div> */}
-            </Link>
-            <Link
-              className="duration-600 flex max-w-xs flex-col gap-4 rounded-xl bg-[--dashboard-background-faded] p-6 transition-transform hover:scale-[1.01]"
-              href="https://github.com/Center-for-AI-Innovation"
-              target="_blank"
-            >
+            </div>
+            <div className="flex max-w-xs flex-col gap-4 rounded-xl bg-[--dashboard-background-faded] p-6">
               <h3
                 className={`
                 text-xl font-bold
@@ -813,13 +838,14 @@ const Home: NextPage = () => {
               >
                 Open source
               </h3>
-              <div className="text-md">MIT License</div>
-            </Link>
-            <Link
-              className="duration-600 flex max-w-xs flex-col gap-4 rounded-xl bg-[--dashboard-background-faded] p-6 transition-transform hover:scale-[1.01]"
-              href="https://ai.ncsa.illinois.edu/"
-              target="_blank"
-            >
+              <a
+                style={{ color: 'var(--illinois-orange)' }}
+                href="mailto:genaisupport@mx.uillinois.edu"
+              >
+                MIT License
+              </a>
+            </div>
+            <div className="flex max-w-xs flex-col gap-4 rounded-xl bg-[--dashboard-background-faded] p-6">
               <h3
                 className={`
                 text-xl font-bold
@@ -829,11 +855,23 @@ const Home: NextPage = () => {
                 Developed at Illinois
               </h3>
               <div className="text-md">
-                Developed by the Center of{' '}
-                <span className="whitespace-nowrap">AI Innovation</span> at the
-                National Center for Supercomputing Applications.
+                Developed by the{' '}
+                <a
+                  style={{ color: 'var(--illinois-orange)' }}
+                  href="https://ai.ncsa.illinois.edu/"
+                >
+                  Center of AI Innovation
+                </a>{' '}
+                at the{' '}
+                <a
+                  style={{ color: 'var(--illinois-orange)' }}
+                  href="https://ncsa.illinois.edu/"
+                >
+                  National Center for Supercomputing Applications
+                </a>
+                .
               </div>
-            </Link>
+            </div>
           </div>
         </div>
         <GlobalFooter />

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -761,32 +761,6 @@ const Home: NextPage = () => {
               </div>
             </div>
           </div>
-
-          <div
-            className="
-              mx-auto flex
-              w-full
-
-              max-w-3xl flex-col items-start justify-center
-              gap-16 sm:flex-row
-            "
-          >
-            <div className="mt-16 sm:w-1/2">
-              <h2
-                className={`
-                text-xl font-bold
-                ${montserrat_heading.variable} font-montserratHeading
-              `}
-              >
-                Want something custom?
-              </h2>
-
-              <div className="mt-4">
-                We build features for industry partners to bring GenAI to their
-                org. Reach out at <a href="mailto:hi@uiuc.chat">hi@uiuc.chat</a>
-              </div>
-            </div>
-          </div>
         </div>
 
         {/* second section below the blue banner */}
@@ -799,10 +773,10 @@ const Home: NextPage = () => {
           >
             About Us
           </h4>
-          <div className="mt-4 grid grid-cols-1 gap-14 sm:grid-cols-2 md:gap-8">
+          <div className="mt-4 grid grid-cols-1 gap-14 sm:grid-cols-3 md:gap-8">
             <Link
               className="duration-600 flex max-w-xs flex-col gap-4 rounded-xl bg-[--dashboard-background-faded] p-6 transition-transform hover:scale-[1.01]"
-              href="https://github.com/Center-for-AI-Innovation/uiuc-chat-frontend"
+              href="mailto:genaisupport@mx.uillinois.edu"
               target="_blank"
             >
               <h3
@@ -811,12 +785,35 @@ const Home: NextPage = () => {
                 ${montserrat_heading.variable} font-montserratHeading
               `}
               >
-                Read the code
+                Support
               </h3>
               <div className="text-md">
-                100% free<br></br>100% open source &#40;MIT License&#41;
-                <br></br>100% awesome
+                If you have any questions or would like to submit a bug please
+                email us at{' '}
+                <a
+                  style={{ color: 'var(--illinois-orange)' }}
+                  href="mailto:genaisupport@mx.uillinois.edu"
+                >
+                  genaisupport@mx.uillinois.edu
+                </a>
+                .
               </div>
+              {/* <div className="text-lg">Sponsored by the </div> */}
+            </Link>
+            <Link
+              className="duration-600 flex max-w-xs flex-col gap-4 rounded-xl bg-[--dashboard-background-faded] p-6 transition-transform hover:scale-[1.01]"
+              href="https://github.com/Center-for-AI-Innovation"
+              target="_blank"
+            >
+              <h3
+                className={`
+                text-xl font-bold
+                ${montserrat_heading.variable} font-montserratHeading
+              `}
+              >
+                Open source
+              </h3>
+              <div className="text-md">MIT License</div>
             </Link>
             <Link
               className="duration-600 flex max-w-xs flex-col gap-4 rounded-xl bg-[--dashboard-background-faded] p-6 transition-transform hover:scale-[1.01]"
@@ -829,75 +826,16 @@ const Home: NextPage = () => {
                 ${montserrat_heading.variable} font-montserratHeading
               `}
               >
-                Sponsored by the Center of{' '}
-                <span className="whitespace-nowrap">AI Innovation</span>
+                Developed at Illinois
               </h3>
               <div className="text-md">
-                Part of the National Center for Supercomputing Applications.
+                Developed by the Center of{' '}
+                <span className="whitespace-nowrap">AI Innovation</span> at the
+                National Center for Supercomputing Applications.
               </div>
-            </Link>
-            <Link
-              className="duration-600 flex max-w-xs flex-col gap-4 rounded-xl bg-[--dashboard-background-faded] p-6 transition-transform hover:scale-[1.01]"
-              href="https://rohanmarwaha.com/"
-              target="_blank"
-            >
-              <h3
-                className={`
-                text-xl font-bold
-                ${montserrat_heading.variable} font-montserratHeading
-              `}
-              >
-                Bio
-              </h3>
-              <div className="text-md">
-                Started by Rohan Marwaha at the University of Illinois. But it{' '}
-                <a
-                  href="https://github.com/Center-for-AI-Innovation/uiuc-chat-frontend/graphs/contributors"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  style={{
-                    textDecoration: 'underline',
-                    textDecorationColor: 'var(--illinois-blue)',
-                  }}
-                >
-                  takes a village
-                </a>
-                .
-              </div>
-              {/* <div className="text-lg">Sponsored by the </div> */}
-            </Link>
-
-            <Link
-              className="duration-600 flex max-w-xs flex-col gap-4 rounded-xl bg-[--dashboard-background-faded] p-6 transition-transform hover:scale-[1.01]"
-              href="https://status.uiuc.chat/"
-              target="_blank"
-            >
-              {/* text-[var(--illinois-white)] hover:bg-[var(--illinois-white)]/20 */}
-              <h3
-                className={`
-                text-xl font-bold
-                ${montserrat_heading.variable} font-montserratHeading
-              `}
-              >
-                Status page
-              </h3>
-              {/* <div className="text-lg">Check service uptime.</div> */}
-              <Image
-                src="https://status.uiuc.chat/api/badge/1/uptime/24?label=Uptime%2024%20hours"
-                alt="Service Uptime Badge"
-                width={150}
-                height={50}
-              />
-              <Image
-                src="https://status.uiuc.chat/api/badge/1/uptime/720?label=Uptime%2030%20days"
-                alt="Service Uptime Badge"
-                width={150}
-                height={50}
-              />
             </Link>
           </div>
         </div>
-
         <GlobalFooter />
       </main>
     </>


### PR DESCRIPTION
Tweaked the footer to fit Illinois.chat deployment. This is a quick fix while we figure out what we want there.

Removed tool tip in banner.

Change About Us section.

Before:

<img width="825" height="530" alt="Screenshot 2025-08-29 at 8 51 03 AM" src="https://github.com/user-attachments/assets/b6ae4d48-2cfe-4a59-8fb3-7406f4cee1d2" />

After:

<img width="1048" height="357" alt="Screenshot 2025-08-29 at 9 31 02 AM" src="https://github.com/user-attachments/assets/42c424a7-c213-43c3-a84e-3d37e942fdd1" />

<img width="1055" height="107" alt="Screenshot 2025-08-29 at 8 56 02 AM" src="https://github.com/user-attachments/assets/5a0af218-5f09-4466-b6f8-bebe37f12069" />
<img width="851" height="620" alt="Screenshot 2025-08-29 at 9 22 17 AM" src="https://github.com/user-attachments/assets/7263c489-85b7-4727-8f32-52616b48aad5" />

