### PR TITLE
add forceEmbeddings as optional ingest parameter

### DIFF
--- a/src/pages/api/UIUC-api/ingest.ts
+++ b/src/pages/api/UIUC-api/ingest.ts
@@ -20,13 +20,15 @@ const handler = async (
       })
     }
 
-    const { uniqueFileName, courseName, readableFilename } = req.body
+    const { uniqueFileName, courseName, readableFilename, forceEmbeddings } =
+      req.body
 
     console.log(
       '👉 Submitting to ingest queue:',
       uniqueFileName,
       courseName,
       readableFilename,
+      forceEmbeddings,
     )
 
     if (!uniqueFileName || !courseName || !readableFilename) {
@@ -48,6 +50,7 @@ const handler = async (
         course_name: courseName,
         readable_filename: readableFilename,
         s3_paths: s3_filepath,
+        force_embeddings: forceEmbeddings,
       }),
     })
 


### PR DESCRIPTION
This exposes the forceEmbeddings parameter used in this backend PR:
https://github.com/Center-for-AI-Innovation/ai-ta-backend/pull/429

...this way, users can choose to programatically recalculate embeddings for files using frontend /ingest endpoint by setting this parameter. e.g.:

```
POST http://localhost:3000/api/UIUC-api/ingest
body: {
   "uniqueFileName":"f38d41ab-56bd-4907-b5f8-8833bb332cbd-README.md",
   "courseName":"resubmit-test",
   "readableFilename":"README.md",
   "forceEmbeddings": "True"
}
```

if forceEmbeddings is absent, ingest happens as before.