### PR TITLE
Fix temperature

### DIFF
--- a/src/components/Chat/Temperature.tsx
+++ b/src/components/Chat/Temperature.tsx
@@ -11,7 +11,7 @@ import {
 import { type Conversation } from '~/types/chat'
 
 export const selectBestTemperature = (
-  lastConversation: Conversation | undefined,
+  lastConversation: Conversation | null | undefined,
   selectedConversation: Conversation | undefined,
   llmProviders: AllLLMProviders,
 ): number => {

--- a/src/db/migrations/0001_custom_functions.sql
+++ b/src/db/migrations/0001_custom_functions.sql
@@ -871,9 +871,7 @@ BEGIN
             AND m.content_text ILIKE '%' || v_search_term || '%'
         )
     )
-    ORDER BY
-        COALESCE(c.updated_at, c.created_at) DESC,
-        c.created_at DESC,
+    ORDER BY c.created_at DESC
     LIMIT v_limit OFFSET v_offset
 )
 SELECT 

--- a/src/db/migrations/0001_custom_functions.sql
+++ b/src/db/migrations/0001_custom_functions.sql
@@ -871,7 +871,9 @@ BEGIN
             AND m.content_text ILIKE '%' || v_search_term || '%'
         )
     )
-    ORDER BY c.created_at DESC
+    ORDER BY
+        COALESCE(c.updated_at, c.created_at) DESC,
+        c.created_at DESC,
     LIMIT v_limit OFFSET v_offset
 )
 SELECT 

--- a/src/hooks/conversationQueries.ts
+++ b/src/hooks/conversationQueries.ts
@@ -1,7 +1,7 @@
 import {
   type QueryClient,
   useInfiniteQuery,
-  useMutation,
+  useMutation, useQuery,
 } from '@tanstack/react-query'
 import { type Conversation, type ConversationPage } from '~/types/chat'
 import { type FolderWithConversation } from '~/types/folder'
@@ -10,6 +10,7 @@ import {
   deleteConversationFromServer,
   fetchConversationHistory,
   saveConversationToServer,
+  fetchLastConversation
 } from '~/utils/app/conversation'
 
 export function useFetchConversationHistory(
@@ -41,6 +42,14 @@ export function useFetchConversationHistory(
       return lastPage.nextCursor ?? null;
     },
     refetchInterval: 20_000,
+  })
+}
+
+export function useFetchLastConversation(courseName: string) {
+  return useQuery<Conversation | null>({
+    queryKey: ['lastConversation', courseName],
+    queryFn: () => fetchLastConversation(courseName),
+    enabled: !!courseName, // don’t run until courseName is truthy
   })
 }
 

--- a/src/utils/app/conversation.ts
+++ b/src/utils/app/conversation.ts
@@ -68,6 +68,35 @@ export async function fetchConversationHistory(
   return finalResponse
 }
 
+export async function fetchLastConversation(
+  courseName: string,
+): Promise<Conversation | null> {
+  try {
+    // Grab the first page; server already orders by updated_at DESC in your SQL,
+    const res = await fetch(
+      `/api/conversation?searchTerm=&courseName=${encodeURIComponent(courseName)}&pageParam=0`,
+      {
+        method: 'GET',
+        headers: { 'Content-Type': 'application/json' },
+      },
+    )
+
+    if (!res.ok) throw new Error('Error fetching last conversation')
+
+    const { conversations } = await res.json()
+
+    if (!Array.isArray(conversations) || conversations.length === 0) {
+      return null
+    }
+
+    // Pick the most recent conversation
+    return conversations[0] ?? null
+  } catch (err) {
+    console.error('Error fetching last conversation:', err)
+    return null
+  }
+}
+
 export const deleteConversationFromServer = async (id: string, course_name: string) => {
   try {
     const response = await fetch('/api/conversation', {


### PR DESCRIPTION
To make everything cleaner, this PR adds a specific API helper and React Query hook to fetch the most recent conversation, and wire it into Home for better default temperature selection.

I cannot reuse the `useFetchConversationHistory` in the `Chatbar.tsx` due to the initial setup is done first before chat bar is loaded; hence the conversation history is never fetched when first time loading. 

---
Another suggestion for the future is in the `search_conversations_v3` which we used to return conversation history.
We are current ordering by created_at, maybe at some point we should order by updated_at? 

```
ORDER BY c.created_at DESC
```

to 

```
ORDER BY
  COALESCE(c.updated_at, c.created_at) DESC,
        c.created_at DESC,
 ...
```

---

To test:

- Create a few projects with varying temerpatures
- Switch between projects to see when "new message" does it fall to the last conversation