### PR TITLE
Fix Keycloak silent token renewal (#689)

### DIFF
--- a/src/config/oidcConfig.ts
+++ b/src/config/oidcConfig.ts
@@ -1,0 +1,49 @@
+import { WebStorageStateStore, type UserManagerSettings } from 'oidc-client-ts'
+import { getKeycloakBaseUrl } from '~/utils/authHelpers'
+
+const KEYCLOAK_REALM = process.env.NEXT_PUBLIC_KEYCLOAK_REALM
+const KEYCLOAK_CLIENT_ID =
+  process.env.NEXT_PUBLIC_KEYCLOAK_CLIENT_ID || 'uiucchat'
+
+/**
+ * Single source of truth for the OIDC `UserManagerSettings`.
+ *
+ * Used by both `KeycloakProvider` (spread into `<AuthProvider>`) and the
+ * `/silent-renew` fallback page (`new UserManager(buildOidcSettings())`) so the
+ * two agree byte-for-byte — any authority/client_id mismatch breaks silent
+ * renewal and callback parsing.
+ *
+ * Must be called in the browser only (reads `window`). Callers gate on mount;
+ * the throw is a guard so a stray SSR/import-time call fails loudly instead of
+ * producing a half-formed config.
+ */
+export function buildOidcSettings(): UserManagerSettings {
+  if (typeof window === 'undefined') {
+    throw new Error('buildOidcSettings() must be called in the browser')
+  }
+
+  const origin = window.location.origin
+
+  return {
+    authority: `${getKeycloakBaseUrl()}realms/${KEYCLOAK_REALM}`,
+    client_id: KEYCLOAK_CLIENT_ID,
+    redirect_uri: origin,
+    silent_redirect_uri: `${origin}/silent-renew`,
+    post_logout_redirect_uri: origin,
+    scope: 'openid profile email',
+    response_type: 'code',
+    // Kept true to preserve existing profile claims behaviour. Adds a
+    // /userinfo round-trip per renewal; can be set false once we confirm the
+    // UI only reads claims already present in the token.
+    loadUserInfo: true,
+    // Refresh-token silent renewal (no iframe for the common path).
+    automaticSilentRenew: true,
+    // Renew well before expiry, with margin for client/server clock skew.
+    accessTokenExpiringNotificationTimeInSeconds: 90,
+    // No check-session iframe: avoids third-party-cookie / CSP frame issues.
+    // Cross-tab logout is therefore not auto-propagated (acceptable: tokens are
+    // short-lived and the watchdog clears on userUnloaded/signedOut).
+    monitorSession: false,
+    userStore: new WebStorageStateStore({ store: window.localStorage }),
+  }
+}

--- a/src/hooks/__tests__/useRenewalWatchdog.test.tsx
+++ b/src/hooks/__tests__/useRenewalWatchdog.test.tsx
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { act, renderHook } from '@testing-library/react'
+
+const initiateSignIn = vi.fn()
+vi.mock('~/utils/authHelpers', () => ({
+  initiateSignIn: (...args: unknown[]) => initiateSignIn(...args),
+}))
+const clearAccessTokenCookie = vi.fn()
+vi.mock('~/utils/auth/accessTokenCookie', () => ({
+  clearAccessTokenCookie: () => clearAccessTokenCookie(),
+}))
+const authMock = vi.fn()
+vi.mock('react-oidc-context', () => ({
+  useAuth: () => authMock(),
+}))
+
+import { useRenewalWatchdog } from '../useRenewalWatchdog'
+
+type Handler = (...args: unknown[]) => void
+
+function makeAuth(signinSilent: () => Promise<unknown>) {
+  const handlers: Record<string, Handler> = {}
+  const unsub = {
+    expired: vi.fn(),
+    renewError: vi.fn(),
+    unloaded: vi.fn(),
+    signedOut: vi.fn(),
+    loaded: vi.fn(),
+  }
+  const events = {
+    addAccessTokenExpired: (cb: Handler) => {
+      handlers.expired = cb
+      return unsub.expired
+    },
+    addSilentRenewError: (cb: Handler) => {
+      handlers.renewError = cb
+      return unsub.renewError
+    },
+    addUserUnloaded: (cb: Handler) => {
+      handlers.unloaded = cb
+      return unsub.unloaded
+    },
+    addUserSignedOut: (cb: Handler) => {
+      handlers.signedOut = cb
+      return unsub.signedOut
+    },
+    addUserLoaded: (cb: Handler) => {
+      handlers.loaded = cb
+      return unsub.loaded
+    },
+  }
+  const auth = { events, signinSilent, isAuthenticated: true, user: null }
+  return { auth, handlers, unsub }
+}
+
+async function flush() {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  })
+}
+
+beforeEach(() => {
+  initiateSignIn.mockReset()
+  clearAccessTokenCookie.mockReset()
+  authMock.mockReset()
+})
+
+describe('useRenewalWatchdog', () => {
+  it('subscribes on mount and unsubscribes on unmount', () => {
+    const { auth, unsub } = makeAuth(vi.fn().mockResolvedValue(null))
+    authMock.mockReturnValue(auth)
+
+    const { unmount } = renderHook(() => useRenewalWatchdog())
+    unmount()
+
+    expect(unsub.expired).toHaveBeenCalled()
+    expect(unsub.renewError).toHaveBeenCalled()
+    expect(unsub.unloaded).toHaveBeenCalled()
+    expect(unsub.signedOut).toHaveBeenCalled()
+    expect(unsub.loaded).toHaveBeenCalled()
+  })
+
+  it('renews on expiry and does not escalate on success', async () => {
+    const signinSilent = vi.fn().mockResolvedValue({ expired: false })
+    const { auth, handlers } = makeAuth(signinSilent)
+    authMock.mockReturnValue(auth)
+
+    renderHook(() => useRenewalWatchdog())
+    handlers.expired?.()
+    await flush()
+
+    expect(signinSilent).toHaveBeenCalledTimes(1)
+    expect(initiateSignIn).not.toHaveBeenCalled()
+  })
+
+  it('escalates after a failed renewal and does not double-escalate while cooling down', async () => {
+    const signinSilent = vi.fn().mockRejectedValue(new Error('renew failed'))
+    const { auth, handlers } = makeAuth(signinSilent)
+    authMock.mockReturnValue(auth)
+
+    renderHook(() => useRenewalWatchdog())
+
+    handlers.renewError?.()
+    await flush()
+    expect(initiateSignIn).toHaveBeenCalledTimes(1)
+
+    // Second event within the cooldown window: renew short-circuits and the
+    // escalation is gated, so login is not triggered again.
+    handlers.expired?.()
+    await flush()
+    expect(initiateSignIn).toHaveBeenCalledTimes(1)
+  })
+
+  it('allows escalation again after a userLoaded event resets the guard', async () => {
+    const signinSilent = vi.fn().mockRejectedValue(new Error('renew failed'))
+    const { auth, handlers } = makeAuth(signinSilent)
+    authMock.mockReturnValue(auth)
+
+    renderHook(() => useRenewalWatchdog())
+
+    handlers.expired?.()
+    await flush()
+    expect(initiateSignIn).toHaveBeenCalledTimes(1)
+
+    handlers.loaded?.() // session recovered → reset the escalation guard
+    handlers.expired?.()
+    await flush()
+    expect(initiateSignIn).toHaveBeenCalledTimes(2)
+  })
+
+  it('clears the cookie on sign-out and user-unloaded', () => {
+    const { auth, handlers } = makeAuth(vi.fn().mockResolvedValue(null))
+    authMock.mockReturnValue(auth)
+
+    renderHook(() => useRenewalWatchdog())
+
+    handlers.unloaded?.()
+    handlers.signedOut?.()
+    expect(clearAccessTokenCookie).toHaveBeenCalledTimes(2)
+  })
+
+  it('coalesces concurrent renewals into a single signinSilent call', async () => {
+    let resolveSilent: (value: unknown) => void = () => {}
+    const signinSilent = vi.fn(
+      () => new Promise((resolve) => (resolveSilent = resolve)),
+    )
+    const { auth, handlers } = makeAuth(signinSilent)
+    authMock.mockReturnValue(auth)
+
+    renderHook(() => useRenewalWatchdog())
+
+    handlers.expired?.() // starts the renewal (signinSilent pending)
+    handlers.renewError?.() // second trigger joins the in-flight renewal
+    await flush()
+    expect(signinSilent).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      resolveSilent({ expired: false })
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+    expect(initiateSignIn).not.toHaveBeenCalled()
+  })
+})

--- a/src/hooks/useRenewalWatchdog.ts
+++ b/src/hooks/useRenewalWatchdog.ts
@@ -1,0 +1,110 @@
+import { useCallback, useEffect, useRef } from 'react'
+import { useAuth } from 'react-oidc-context'
+
+import { clearAccessTokenCookie } from '~/utils/auth/accessTokenCookie'
+import { initiateSignIn } from '~/utils/authHelpers'
+
+const RENEW_COOLDOWN_MS = 5000
+// Cap how long we wait for a silent renewal. The refresh-token grant goes
+// through fetch with no client-side timeout, so without this a hung token
+// request would leave `inFlightRef` set forever and suppress all future
+// renewals/escalation.
+const RENEW_TIMEOUT_MS = 15000
+
+/**
+ * Sitewide token-renewal safety net. Mounted once (inside the OIDC provider).
+ *
+ * - On access-token expiry / silent-renew error: attempts one renewal
+ *   (single-flight + cooldown so overlapping events don't storm Keycloak).
+ *   Only if that fails (refresh token truly dead) does it escalate to
+ *   interactive login. Never redirects on the first hiccup.
+ * - Clears the chunked cookie set on definitive sign-out / user-unloaded.
+ *
+ * `automaticSilentRenew`'s internal timer handles the steady-state renewal; the
+ * primary multi-tab safeguard is disabling Keycloak refresh-token rotation (so
+ * a not-yet-rotated token keeps working across tabs).
+ */
+export function useRenewalWatchdog(): void {
+  const auth = useAuth()
+  const escalatedRef = useRef(false)
+  const inFlightRef = useRef<Promise<boolean> | null>(null)
+  const lastAttemptRef = useRef(0)
+
+  // Single-flight, cooldown-guarded renewal. Resolves true if a fresh, valid
+  // token is available afterwards.
+  const renew = useCallback(async (): Promise<boolean> => {
+    if (inFlightRef.current) return inFlightRef.current
+    if (Date.now() - lastAttemptRef.current < RENEW_COOLDOWN_MS) return false
+    lastAttemptRef.current = Date.now()
+
+    inFlightRef.current = (async () => {
+      let timer: ReturnType<typeof setTimeout> | undefined
+      try {
+        const user = await Promise.race([
+          // .catch keeps a late rejection from becoming unhandled if the
+          // timeout already won the race.
+          auth.signinSilent().catch(() => null),
+          new Promise<null>((resolve) => {
+            timer = setTimeout(() => resolve(null), RENEW_TIMEOUT_MS)
+          }),
+        ])
+        return !!user && !user.expired
+      } finally {
+        if (timer) clearTimeout(timer)
+        inFlightRef.current = null
+      }
+    })()
+    return inFlightRef.current
+  }, [auth])
+
+  useEffect(() => {
+    const events = auth.events
+    if (!events) return
+
+    const escalate = () => {
+      if (escalatedRef.current) return
+      escalatedRef.current = true
+      try {
+        const redirectPath =
+          typeof window !== 'undefined'
+            ? window.location.pathname + window.location.search
+            : '/'
+        void initiateSignIn(auth, redirectPath)
+      } catch {
+        /* escalation is best-effort */
+      }
+    }
+
+    const handleExpiredOrError = async () => {
+      const ok = await renew()
+      if (ok) {
+        // Recovered — allow a future failure to escalate again.
+        escalatedRef.current = false
+      } else {
+        escalate()
+      }
+    }
+
+    const handleSignedOut = () => clearAccessTokenCookie()
+
+    const offExpired = events.addAccessTokenExpired(() => {
+      void handleExpiredOrError()
+    })
+    const offRenewError = events.addSilentRenewError(() => {
+      void handleExpiredOrError()
+    })
+    const offUnloaded = events.addUserUnloaded(handleSignedOut)
+    const offSignedOut = events.addUserSignedOut(handleSignedOut)
+    const offLoaded = events.addUserLoaded(() => {
+      escalatedRef.current = false
+    })
+
+    return () => {
+      offExpired?.()
+      offRenewError?.()
+      offUnloaded?.()
+      offSignedOut?.()
+      offLoaded?.()
+    }
+  }, [auth, renew])
+}

--- a/src/pages/silent-renew.tsx
+++ b/src/pages/silent-renew.tsx
@@ -1,0 +1,24 @@
+import { useEffect } from 'react'
+import { UserManager } from 'oidc-client-ts'
+import { buildOidcSettings } from '~/config/oidcConfig'
+
+/**
+ * OIDC silent-renew callback target (loaded inside a hidden iframe).
+ *
+ * This is the FALLBACK renewal path: with a refresh token present,
+ * oidc-client-ts renews via the refresh-token grant and never loads this page.
+ * It exists to (a) remove the previously-dangling `silent_redirect_uri` 404 and
+ * (b) handle the iframe path if no refresh token is available. It parses the
+ * auth response from the URL and postMessages the result to the parent window's
+ * UserManager.
+ */
+export default function SilentRenew() {
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    new UserManager(buildOidcSettings())
+      .signinSilentCallback()
+      .catch((err) => console.error('Silent renew callback failed:', err))
+  }, [])
+
+  return null
+}

--- a/src/providers/AuthCookie.tsx
+++ b/src/providers/AuthCookie.tsx
@@ -1,49 +1,39 @@
 import React, { useEffect, useState } from 'react'
 import { useAuth } from 'react-oidc-context'
 
-import { CookieStorage } from '~/providers/CookieStorage'
-import { useRouter } from 'next/router'
+import { writeAccessTokenCookie } from '~/utils/auth/accessTokenCookie'
+import { useRenewalWatchdog } from '~/hooks/useRenewalWatchdog'
 
 export function AuthCookie({ children }: { children: React.ReactNode }) {
   const auth = useAuth()
-  const router = useRouter()
   const [cookieWritten, setCookieWritten] = useState(false)
-  const cookieStore = new CookieStorage()
 
+  // Renewal + cookie-clearing on logout live in the watchdog (mounted here so
+  // it's inside the OIDC provider and wraps the whole app).
+  useRenewalWatchdog()
+
+  const token = auth.user?.access_token
+
+  // Persist the access token whenever it changes — including after each silent
+  // renewal (keyed on the token string, NOT gated on isLoading, so a renewed
+  // token is written through immediately). Removal is NOT done here: a transient
+  // unauthenticated render must not wipe the cookie; the watchdog clears it on
+  // sign-out / user-unloaded.
   useEffect(() => {
-    try {
-      if (auth.isAuthenticated && auth.user) {
-        cookieStore.setItem('access_token', auth.user.access_token)
-        // Mark cookie as written after the operation completes successfully
-        setCookieWritten(true)
-      } else {
-        cookieStore.removeItem('access_token')
-        // setCookieWritten(false)
-      }
-    } catch (error) {
-      console.error('Failed to write cookie:', error)
-      // Still set to true to prevent infinite loading, but log the error
-      setCookieWritten(true)
-    }
-  }, [auth, cookieStore, router])
-
-  // TODO make full pages with styling
-  // switch (auth.activeNavigator) {
-  //   case "signinSilent":
-  //     return <div>Signing you in...</div>;
-  //   case "signoutRedirect":
-  //     return <div>Signing you out...</div>;
-  // }
-
-  // Don't render children until auth is loaded AND cookie is written
-  if (auth.isAuthenticated && !cookieWritten) {
-    return <div>Loading... </div>
-  }
+    if (!auth.isAuthenticated || !token) return
+    writeAccessTokenCookie(token)
+    setCookieWritten(true)
+  }, [token, auth.isAuthenticated])
 
   if (auth.error) {
     return <div>Oops... {auth.error.message}</div>
   }
 
-  // At this point, cookieWritten is guaranteed to be true
+  // Don't render children until the cookie is written for authenticated users,
+  // so no page component fires an API request before the token cookie exists.
+  if (auth.isAuthenticated && !cookieWritten) {
+    return <div>Loading... </div>
+  }
+
   return <>{children}</>
 }

--- a/src/providers/KeycloakProvider.tsx
+++ b/src/providers/KeycloakProvider.tsx
@@ -1,7 +1,12 @@
-import { AuthProvider, useAuth } from 'react-oidc-context'
-import React, { type ReactNode, useEffect, useState } from 'react'
-import { WebStorageStateStore } from 'oidc-client-ts'
-import { getKeycloakBaseUrl } from '~/utils/authHelpers'
+import { AuthProvider } from 'react-oidc-context'
+import React, {
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react'
+import { buildOidcSettings } from '~/config/oidcConfig'
 import Link from 'next/link'
 import { montserrat_heading } from '../../fonts'
 import { Flex, Title } from '@mantine/core'
@@ -28,11 +33,6 @@ const isValidRedirectPath = (path: string): boolean => {
 }
 // ---------------------------------------
 
-const getBaseUrl = () => {
-  if (typeof window === 'undefined') return ''
-  return window.location.origin
-}
-
 // Function to save the current path before login
 const saveCurrentPath = () => {
   if (typeof window !== 'undefined') {
@@ -52,75 +52,51 @@ export const KeycloakProvider = ({ children }: AuthProviderProps) => {
   const [isMounted, setIsMounted] = useState(false)
   const [isAuthCallback, setIsAuthCallback] = useState(false)
 
-  const [oidcConfig, setOidcConfig] = useState({
-    authority: `${getKeycloakBaseUrl()}realms/${
-      process.env.NEXT_PUBLIC_KEYCLOAK_REALM
-    }`,
-    client_id: process.env.NEXT_PUBLIC_KEYCLOAK_CLIENT_ID || 'uiucchat',
-    redirect_uri: '',
-    silent_redirect_uri: '',
-    post_logout_redirect_uri: '',
-    scope: 'openid profile email',
-    response_type: 'code',
-    loadUserInfo: true,
-    onSigninCallback: async () => {
-      if (typeof window !== 'undefined') {
-        let redirectPath = sessionStorage.getItem('auth_redirect_path') || '/'
+  // Stable signin-callback: restore the pre-login path and hand off.
+  const handleSigninCallback = useCallback(async () => {
+    if (typeof window === 'undefined') return
 
-        if (!isValidRedirectPath(redirectPath)) {
-          redirectPath = '/'
-        }
+    let redirectPath = sessionStorage.getItem('auth_redirect_path') || '/'
+    if (!isValidRedirectPath(redirectPath)) {
+      redirectPath = '/'
+    }
 
-        // Extra logic: if root path and Illinois Chat config enabled → go to /chat
-        if (
-          redirectPath === '/' &&
-          process.env.NEXT_PUBLIC_USE_ILLINOIS_CHAT_CONFIG === 'True'
-        ) {
-          redirectPath = '/chat'
-        }
+    // Extra logic: if root path and Illinois Chat config enabled → go to /chat
+    if (
+      redirectPath === '/' &&
+      process.env.NEXT_PUBLIC_USE_ILLINOIS_CHAT_CONFIG === 'True'
+    ) {
+      redirectPath = '/chat'
+    }
 
-        sessionStorage.removeItem('auth_redirect_path')
-        window.location.replace(redirectPath)
-        // TODO: This doesn't work even though it's recommended in the react-oidc-context docs
-        // window.history.replaceState({}, document.title, redirectPath)
-      }
-    },
-  })
+    sessionStorage.removeItem('auth_redirect_path')
+    window.location.replace(redirectPath)
+  }, [])
+
+  // Build the COMPLETE OIDC settings once, on the client, before <AuthProvider>
+  // mounts. react-oidc-context constructs the UserManager from these props a
+  // single time and does NOT rebuild it when props change later, so they must
+  // be complete on first render (incl. automaticSilentRenew + userStore).
+  const oidcSettings = useMemo(
+    () =>
+      isMounted && typeof window !== 'undefined' ? buildOidcSettings() : null,
+    [isMounted],
+  )
 
   // Set up client-side values after mount
   useEffect(() => {
-    if (typeof window !== 'undefined') {
-      const baseUrl = getBaseUrl()
-      const searchParams = new URLSearchParams(window.location.search)
-      setIsAuthCallback(searchParams.has('code') && searchParams.has('state'))
-      setIsMounted(true)
+    if (typeof window === 'undefined') return
 
-      // const cookieStore = new CookieStorage({
-      //   prefix: '',
-      //   expiresDays: 1,
-      //   sameSite: 'lax', // if your IdP is on another domain AND you use iframe silent renew, use "none"
-      //   secure: window.location.protocol === 'https:',
-      // })
-      // const cookieStore = new CookieStorage()
+    const searchParams = new URLSearchParams(window.location.search)
+    setIsAuthCallback(searchParams.has('code') && searchParams.has('state'))
+    setIsMounted(true)
 
-      setOidcConfig((prev) => ({
-        ...prev,
-        redirect_uri: baseUrl,
-        silent_redirect_uri: `${baseUrl}/silent-renew`,
-        post_logout_redirect_uri: baseUrl,
-        userStore: new WebStorageStateStore({
-          store: window.localStorage,
-        }),
-        automaticSilentRenew: true,
-      }))
-
-      // Only save the path when component mounts if we're not on the callback URL
-      if (
-        !window.location.search.includes('state=') &&
-        !window.location.search.includes('code=')
-      ) {
-        saveCurrentPath()
-      }
+    // Only save the path when component mounts if we're not on the callback URL
+    if (
+      !window.location.search.includes('state=') &&
+      !window.location.search.includes('code=')
+    ) {
+      saveCurrentPath()
     }
   }, [])
 
@@ -192,12 +168,12 @@ export const KeycloakProvider = ({ children }: AuthProviderProps) => {
     }
   }, [isMounted])
 
-  if (typeof window === 'undefined' || !isMounted) return null
+  if (typeof window === 'undefined' || !isMounted || !oidcSettings) return null
 
   return (
-    <AuthProvider {...oidcConfig}>
+    <AuthProvider {...oidcSettings} onSigninCallback={handleSigninCallback}>
       <AuthCookie>
-        {/*If we’re on the callback URL, render a handoff screen instead of the app.*/}
+        {/*If we're on the callback URL, render a handoff screen instead of the app.*/}
         {isAuthCallback ? (
           <>
             <main

--- a/src/providers/__tests__/AuthCookie.test.tsx
+++ b/src/providers/__tests__/AuthCookie.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+// Mocks must be defined before importing the component under test.
+const useAuthMock = vi.fn()
+vi.mock('react-oidc-context', () => ({
+  useAuth: () => useAuthMock(),
+}))
+vi.mock('~/hooks/useRenewalWatchdog', () => ({
+  useRenewalWatchdog: vi.fn(),
+}))
+const writeAccessTokenCookie = vi.fn()
+vi.mock('~/utils/auth/accessTokenCookie', () => ({
+  writeAccessTokenCookie: (token: string) => writeAccessTokenCookie(token),
+}))
+
+import { AuthCookie } from '../AuthCookie'
+
+beforeEach(() => {
+  useAuthMock.mockReset()
+  writeAccessTokenCookie.mockReset()
+})
+
+describe('AuthCookie', () => {
+  it('writes the cookie and renders children for an authenticated user', () => {
+    useAuthMock.mockReturnValue({
+      isAuthenticated: true,
+      user: { access_token: 'tok' },
+    })
+
+    render(
+      <AuthCookie>
+        <div>protected content</div>
+      </AuthCookie>,
+    )
+
+    expect(screen.getByText('protected content')).toBeInTheDocument()
+    expect(writeAccessTokenCookie).toHaveBeenCalledWith('tok')
+  })
+
+  it('renders children for an unauthenticated user without writing cookies', () => {
+    useAuthMock.mockReturnValue({ isAuthenticated: false, user: undefined })
+
+    render(
+      <AuthCookie>
+        <div>public content</div>
+      </AuthCookie>,
+    )
+
+    expect(screen.getByText('public content')).toBeInTheDocument()
+    expect(writeAccessTokenCookie).not.toHaveBeenCalled()
+  })
+})

--- a/src/utils/__tests__/appRouterAuth.test.ts
+++ b/src/utils/__tests__/appRouterAuth.test.ts
@@ -51,6 +51,31 @@ describe('withAppRouterAuth', () => {
     await expect(res.json()).resolves.toMatchObject({ user: { sub: 'u1' } })
   })
 
+  it('extracts the token despite empty, valueless, and malformed-encoded cookie segments', async () => {
+    const verifyTokenAsync = vi.fn().mockResolvedValue({ sub: 'u1' })
+    const getKeycloakBaseFromHost = vi.fn(() => 'https://kc/')
+    vi.doMock('../keycloakClient', () => ({ verifyTokenAsync }))
+    vi.doMock('~/utils/authHelpers', () => ({ getKeycloakBaseFromHost }))
+
+    vi.resetModules()
+    const { withAppRouterAuth } = await import('../appRouterAuth')
+
+    const handler = vi.fn((req: any) => NextResponse.json({ user: req.user }))
+    const wrapped = withAppRouterAuth(handler as any)
+
+    const req: any = {
+      // '' (empty) → skipped; 'novalue' (no '=') → skipped; 'bad=%E0%A4%A'
+      // (malformed percent-encoding) → falls back to the raw value via catch.
+      headers: new Headers({
+        cookie: 'access_token=t; ; novalue; bad=%E0%A4%A',
+      }),
+    }
+
+    const res = await wrapped(req)
+    expect(verifyTokenAsync).toHaveBeenCalledWith('t', 'https://kc/')
+    await expect(res.json()).resolves.toMatchObject({ user: { sub: 'u1' } })
+  })
+
   it('returns 401 TokenExpiredError when token is expired', async () => {
     vi.spyOn(console, 'error').mockImplementation(() => {})
     const verifyTokenAsync = vi

--- a/src/utils/appRouterAuth.ts
+++ b/src/utils/appRouterAuth.ts
@@ -5,22 +5,28 @@ import { getKeycloakBaseFromHost } from '~/utils/authHelpers'
 import { verifyTokenAsync } from './keycloakClient'
 
 function getTokenFromCookies(req: NextRequest): string | null {
-  // Find oidc.user* cookie
   const cookieHeader = req.headers.get('cookie')
   if (!cookieHeader) return null
 
-  const cookies = cookieHeader.split(';').reduce(
-    (acc, cookie) => {
-      const [name, value] = cookie.trim().split('=')
-      if (name) acc[name] = value ?? ''
-      return acc
-    },
-    {} as Record<string, string>,
-  )
+  // Parse the cookie header into a decoded map. Split on the FIRST '=' only
+  // (cookie values may contain '=') and decode each value so it matches the
+  // semantics of Next's `req.cookies` used by the Pages gate.
+  const cookies: Record<string, string> = {}
+  for (const part of cookieHeader.split(';')) {
+    const trimmed = part.trim()
+    if (!trimmed) continue
+    const eq = trimmed.indexOf('=')
+    if (eq === -1) continue
+    const name = trimmed.slice(0, eq)
+    const rawValue = trimmed.slice(eq + 1)
+    try {
+      cookies[name] = decodeURIComponent(rawValue)
+    } catch {
+      cookies[name] = rawValue
+    }
+  }
 
-  const raw = cookies['access_token']
-  if (!raw) return null
-  return raw
+  return cookies['access_token'] ?? null
 }
 
 export interface AuthenticatedRequest extends NextRequest {
@@ -61,8 +67,6 @@ export function withAppRouterAuth(
       const rawHost =
         req.headers.get('x-forwarded-host') ?? req.headers.get('host')
       const hostValue = Array.isArray(rawHost) ? rawHost[0] : rawHost
-
-      console.log('Host value:', hostValue)
 
       // Fallback to 'localhost' if undefined
       const hostname = (hostValue ?? 'localhost').split(':')[0]

--- a/src/utils/auth/__tests__/accessTokenCookie.test.ts
+++ b/src/utils/auth/__tests__/accessTokenCookie.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  writeAccessTokenCookie,
+  clearAccessTokenCookie,
+  ACCESS_TOKEN_COOKIE,
+} from '../accessTokenCookie'
+
+function cookieMap(): Record<string, string> {
+  const map: Record<string, string> = {}
+  for (const part of document.cookie.split(';')) {
+    const trimmed = part.trim()
+    if (!trimmed) continue
+    const eq = trimmed.indexOf('=')
+    if (eq === -1) continue
+    map[trimmed.slice(0, eq)] = decodeURIComponent(trimmed.slice(eq + 1))
+  }
+  return map
+}
+
+function clearAllCookies(): void {
+  for (const part of document.cookie.split(';')) {
+    const name = part.trim().split('=')[0]
+    if (name) {
+      document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/`
+    }
+  }
+}
+
+beforeEach(() => clearAllCookies())
+
+describe('accessTokenCookie', () => {
+  it('writes the access token to a single cookie', () => {
+    writeAccessTokenCookie('header.payload.signature')
+    expect(cookieMap()[ACCESS_TOKEN_COOKIE]).toBe('header.payload.signature')
+  })
+
+  it('overwrites the cookie when the token is renewed', () => {
+    writeAccessTokenCookie('old.token')
+    writeAccessTokenCookie('new.token')
+    expect(cookieMap()[ACCESS_TOKEN_COOKIE]).toBe('new.token')
+  })
+
+  it('clears the access-token cookie', () => {
+    writeAccessTokenCookie('a.b.c')
+    clearAccessTokenCookie()
+    expect(cookieMap()[ACCESS_TOKEN_COOKIE]).toBeUndefined()
+  })
+})

--- a/src/utils/auth/accessTokenCookie.ts
+++ b/src/utils/auth/accessTokenCookie.ts
@@ -1,0 +1,26 @@
+// Browser-side read/write of the access-token cookie that the server gates
+// (`withAuth` / `withAppRouterAuth`) read. Kept as a tiny module so the cookie
+// name + options live in one place, shared by AuthCookie (write on token
+// change) and the renewal watchdog (clear on sign-out).
+
+import { CookieStorage } from '~/providers/CookieStorage'
+
+export const ACCESS_TOKEN_COOKIE = 'access_token'
+
+function makeStore(): CookieStorage {
+  return new CookieStorage({
+    // Mark Secure only on https so localhost (http) dev still sends the cookie.
+    secure:
+      typeof window !== 'undefined' && window.location.protocol === 'https:',
+  })
+}
+
+/** Persist the access token so server gates can read it from the cookie. */
+export function writeAccessTokenCookie(token: string): void {
+  makeStore().setItem(ACCESS_TOKEN_COOKIE, token)
+}
+
+/** Remove the access-token cookie (on sign-out / user-unloaded). */
+export function clearAccessTokenCookie(): void {
+  makeStore().removeItem(ACCESS_TOKEN_COOKIE)
+}

--- a/src/utils/authMiddleware.ts
+++ b/src/utils/authMiddleware.ts
@@ -5,9 +5,7 @@ import { getKeycloakBaseFromHost } from '~/utils/authHelpers'
 import { AuthenticatedUser } from '~/middleware'
 
 function getTokenFromCookies(req: NextApiRequest): string | null {
-  const raw = req.cookies['access_token']
-  if (!raw) return null
-  return raw
+  return req.cookies['access_token'] ?? null
 }
 
 export interface AuthenticatedRequest extends NextApiRequest {

--- a/src/utils/keycloakClient.ts
+++ b/src/utils/keycloakClient.ts
@@ -135,6 +135,9 @@ export function createTokenVerifier(keycloakBaseUrl?: string) {
     options: {
       issuer: `${keycloakBaseUrl}realms/${KEYCLOAK_REALM}`,
       algorithms: ['RS256'] as jwt.Algorithm[],
+      // Tolerate small client/server clock differences near `exp` so a token
+      // the client still considers valid isn't rejected as expired.
+      clockTolerance: 30,
     },
   }
 }


### PR DESCRIPTION
Closes #689.

## What this does
Before this PR, once a logged-in user's short-lived Keycloak access token expired it was **never silently renewed**, so `withAuth`-gated API requests started failing with **401 "Token expired"** while the UI still looked logged in (OIDC state lives in `localStorage`).

Renewal was non-functional for three reasons, all fixed here:
- `automaticSilentRenew` was on but `silent_redirect_uri` pointed at a **non-existent `/silent-renew` page**, and OIDC settings were finalized in a post-mount `setState` so the `UserManager` could be built before renewal/storage settings applied.
- Nothing refreshed the `access_token` cookie after a renewal, so even a successful renew didn't reach the server gates.
- Renewal failures weren't handled.

### Changes
- **`buildOidcSettings()`** — single source of truth for OIDC settings, built complete (incl. `automaticSilentRenew`, `userStore`) **before `<AuthProvider>` mounts**, so renewal arms reliably.
- **`/silent-renew` page** — real fallback target (was a dangling 404).
- **`AuthCookie`** — writes the `access_token` cookie on every token change (incl. each renewal); the **renewal watchdog** clears it on sign-out / user-unloaded.
- **`useRenewalWatchdog`** — single-flight + cooldown + 15s timeout-guarded `signinSilent`; attempts renewal on expiry/error and escalates to interactive login **only after a genuine failure** (never on the first transient hiccup).
- **`clockTolerance`** on server-side JWT verification to avoid spurious expiry near `exp`.

> Note: this does **not** include the earlier cookie-chunking workaround for oversized tokens. That "Missing token" issue was specific to the old Keycloak instance (an ever-growing `allowed-origins` claim from accumulated Vercel preview URLs). The app now targets the properly-configured Keycloak where the access token is small, so a single `access_token` cookie is sufficient.

## Keycloak settings to confirm (admins)
Target client: **`illinois_chat`** in realm **`illinois_chat_realm`** (issuer `https://chat.illinois.edu/keycloak/realms/illinois_chat_realm`). Based on a current prod token, most of this is already in place — please just confirm:

1. **Web Origins** (CORS for the refresh-token `POST` to the token endpoint) — must include every origin the app is served from. The prod token's `allowed-origins` already shows `https://chat.illinois.edu` and `https://ilchat.mss.illinois.edu`; confirm both (and any others) are present. Missing this → the browser blocks the renewal request with a CORS error.
2. **Valid Redirect URIs** — must include `<origin>/silent-renew` for each app origin, e.g. `https://chat.illinois.edu/silent-renew` and `https://ilchat.mss.illinois.edu/silent-renew` (a `https://chat.illinois.edu/*` entry covers it).
3. **Disable refresh-token rotation** — set **Revoke Refresh Token = Off** (Realm settings → Tokens), or confirm it's off, so concurrent renewals from multiple tabs don't invalidate each other and log the user out.
4. **Refresh tokens enabled** and **SSO Session Idle/Max** long enough that the refresh token outlives the access token for the intended session length.

## Env var to confirm (deploy config)
- **`NEXT_PUBLIC_KEYCLOAK_URL` must be set to `https://chat.illinois.edu/keycloak/`** (note the `/keycloak/` path) and be **identical for the frontend and server**. This matters: the token issuer is fixed at `chat.illinois.edu/keycloak` regardless of which host serves the app, so when the app is served from `ilchat.mss.illinois.edu` the host-derived fallback would compute the wrong authority and JWT verification would fail. Setting the env var explicitly avoids that.

## How to verify
Log in, open DevTools → Network. Temporarily lower the realm **Access Token Lifespan** to ~1–2 min. You should see:
- a background `POST .../token` with `grant_type=refresh_token` returning **200** (no CORS error, and **no** request to `/silent-renew` on the refresh-token path),
- the `access_token` cookie value rotating, and
- `/api/...` calls continuing to return **200** — no "Token expired".

## Tests
Full suite green (252 files / 1945 tests), incl. updated `AuthCookie` and `accessTokenCookie` tests.